### PR TITLE
feat: When selecting a purchase invoice for an asset, show only 'update stock' Purchase Invoice

### DIFF
--- a/assets/assets/doctype/asset/asset.js
+++ b/assets/assets/doctype/asset/asset.js
@@ -79,7 +79,8 @@ frappe.ui.form.on("Asset", {
 				query: "assets.controllers.queries.get_purchase_invoices",
 				filters: {
 					item_code: doc.item_code,
-					company: frm.doc.company
+					company: frm.doc.company,
+					update_stock: 1
 				},
 			};
 		});

--- a/assets/controllers/queries.py
+++ b/assets/controllers/queries.py
@@ -40,5 +40,10 @@ def get_purchase_invoices(doctype, txt, searchfield, start, page_len, filters):
 		query += " and pi.company = {company}".format(
 			company = frappe.db.escape(filters.get("company"))
 		)
+		
+	if filters and filters.get("update_stock"):
+		query += " and pi.update_stock = {update_stock}".format(
+			update_stock=filters.get("update_stock")
+		)
 
 	return frappe.db.sql(query, filters)


### PR DESCRIPTION
The issue is raised on erpnext repository : https://github.com/8848digital/erpnext/issues/346
Applied update_stock filter for purchase invoice in js file
Modified get_purchase_invoice function in queries.py to return purchase invoice according to filter