### PR TITLE
feat: asset movement customization

### DIFF
--- a/assets/assets/doctype/asset/asset.py
+++ b/assets/assets/doctype/asset/asset.py
@@ -400,8 +400,16 @@ class Asset(AccountsController):
 				"asset_name": self.asset_name,
 				"target_location": self.location,
 				"to_employee": self.custodian,
+				"target_cost_center": self.cost_center,
 			}
 		]
+		fields = frappe.get_list("Accounting Dimension", pluck="fieldname")
+		transformed_fields = [f"target_{field}" for field in fields]
+
+		for field in transformed_fields:
+			original_fieldname = field.replace("target_", "")
+			assets[0][field] = getattr(self, original_fieldname, None)
+
 		asset_movement = frappe.get_doc(
 			{
 				"doctype": "Asset Movement",
@@ -1081,14 +1089,22 @@ def make_asset_movement(assets, purpose=None):
 	for asset in assets:
 		asset = frappe.get_doc("Asset", asset.get("name"))
 		asset_movement.company = asset.get("company")
-		asset_movement.append(
-			"assets",
-			{
-				"asset": asset.get("name"),
-				"source_location": asset.get("location"),
-				"from_employee": asset.get("custodian"),
-			},
-		)
+
+		asset_dict = {
+			"asset": asset.get("name"),
+			"source_location": asset.get("location"),
+			"from_employee": asset.get("custodian"),
+			"source_cost_center": asset.get("cost_center"),
+		}
+
+		fields = frappe.get_list("Accounting Dimension", pluck="fieldname")
+		transformed_fields = [f"source_{field}" for field in fields]
+
+		for field in transformed_fields:
+			original_fieldname = field.replace("source_", "")
+			asset_dict[field] = asset.get(original_fieldname, None)
+
+		asset_movement.append("assets", asset_dict)
 
 	if asset_movement.get("assets"):
 		return asset_movement.as_dict()

--- a/assets/assets/doctype/asset/depreciation.py
+++ b/assets/assets/doctype/asset/depreciation.py
@@ -343,6 +343,7 @@ def _make_journal_entry_for_depreciation(
 					or dimension.get("default_dimension")
 				}
 			)
+	update_dimension_fields(asset_depr_schedule_doc.name, credit_entry, debit_entry)
 
 	je.append("accounts", credit_entry)
 	je.append("accounts", debit_entry)
@@ -360,6 +361,24 @@ def _make_journal_entry_for_depreciation(
 		row = asset.get("finance_books")[idx - 1]
 		row.value_after_depreciation -= depr_schedule.depreciation_amount
 		row.db_update()
+
+
+def update_dimension_fields(asset_depr_schedule_doc_name, credit_entry, debit_entry):
+	additional_fields = {}
+	fieldnames = frappe.get_list("Accounting Dimension", pluck="fieldname")
+	for fieldname in fieldnames:
+		field_data = frappe.db.get_value(
+			"Asset Depreciation Schedule", asset_depr_schedule_doc_name, fieldname
+		)
+		additional_fields[fieldname] = field_data
+
+	cost_center = frappe.db.get_value(
+		"Asset Depreciation Schedule", asset_depr_schedule_doc_name, "cost_center"
+	)
+	additional_fields["cost_center"] = cost_center
+
+	credit_entry.update(additional_fields)
+	debit_entry.update(additional_fields)
 
 
 def get_depreciation_accounts(asset_category, company):

--- a/assets/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.json
+++ b/assets/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.json
@@ -27,6 +27,8 @@
   "expected_value_after_useful_life",
   "depreciation_schedule_section",
   "depreciation_schedule",
+  "accounting_dimensions_section",
+  "cost_center",
   "details_section",
   "notes",
   "status",
@@ -104,6 +106,7 @@
    "label": "Depreciation Schedule"
   },
   {
+    "allow_on_submit": 1,
    "fieldname": "depreciation_schedule",
    "fieldtype": "Table",
    "label": "Depreciation Schedule",
@@ -202,12 +205,24 @@
    "label": "Company",
    "options": "Company",
    "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "accounting_dimensions_section",
+   "fieldtype": "Section Break",
+   "label": "Accounting Dimensions"
+  },
+  {
+   "fieldname": "cost_center",
+   "fieldtype": "Link",
+   "label": "Cost Center",
+   "options": "Cost Center"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-01-08 16:31:04.533928",
+ "modified": "2024-09-23 06:37:47.550658",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Depreciation Schedule",

--- a/assets/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/assets/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -30,13 +30,12 @@ class AssetDepreciationSchedule(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		from assets.assets.doctype.depreciation_schedule.depreciation_schedule import (
-			DepreciationSchedule,
-		)
+		from assets.assets.doctype.depreciation_schedule.depreciation_schedule import DepreciationSchedule
 
 		amended_from: DF.Link | None
 		asset: DF.Link
 		company: DF.Link | None
+		cost_center: DF.Link | None
 		daily_prorata_based: DF.Check
 		depreciation_method: DF.Literal[
 			"", "Straight Line", "Double Declining Balance", "Written Down Value", "Manual"
@@ -49,8 +48,8 @@ class AssetDepreciationSchedule(Document):
 		gross_purchase_amount: DF.Currency
 		naming_series: DF.Literal["ACC-ADS-.YYYY.-"]
 		notes: DF.SmallText | None
-		opening_number_of_booked_depreciations: DF.Int
 		opening_accumulated_depreciation: DF.Currency
+		opening_number_of_booked_depreciations: DF.Int
 		rate_of_depreciation: DF.Percent
 		shift_based: DF.Check
 		status: DF.Literal["Draft", "Active", "Cancelled"]
@@ -220,7 +219,12 @@ class AssetDepreciationSchedule(Document):
 		self.expected_value_after_useful_life = row.expected_value_after_useful_life
 		self.daily_prorata_based = row.daily_prorata_based
 		self.shift_based = row.shift_based
+		self.cost_center = asset_doc.cost_center
 		self.status = "Draft"
+
+		fields = frappe.get_list("Accounting Dimension", pluck="fieldname")
+		for field in fields:
+			setattr(self, field, getattr(asset_doc, field, None))
 
 	def make_depr_schedule(
 		self,

--- a/assets/assets/doctype/asset_movement/asset_movement.js
+++ b/assets/assets/doctype/asset_movement/asset_movement.js
@@ -2,6 +2,70 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Asset Movement", {
+	refresh: function (frm) {
+		if (frm.doc.purpose == "Transfer" && frm.doc.docstatus == 1) {
+			if (!frm.doc.journal_entry) {
+				frm.add_custom_button(
+					__("Make Journal Entry"),
+					function () {
+						frappe.confirm("Are you sure you want to proceed?", () => {
+							frappe.call({
+								method: "assets.assets.doctype.asset_movement.asset_movement.make_asset_movement_entry",
+								args: {
+									asset_movement_name: frm.doc.name,
+									transaction_date: frm.doc.transaction_date,
+									company: frm.doc.company,
+								},
+								callback: function (r) {
+									frappe.model.sync(r.message);
+									frm.refresh();
+								},
+							});
+						});
+					},
+					__("Create")
+				);
+			}
+			frm.add_custom_button(
+				__("Make Delivery Note"),
+				function () {
+					frappe.confirm(
+						"Are you sure you want to proceed?",
+						() => {
+							frappe.call({
+								method: "assets.assets.doctype.asset_movement.asset_movement.make_delivery_note",
+								args: {
+									name: frm.doc.name,
+									transaction_date: frm.doc.transaction_date,
+								},
+								callback: function (r) {
+									frappe.model.with_doctype("Delivery Note", function () {
+										var doc = frappe.model.get_new_doc("Delivery Note");
+										var items = r.message;
+										var child = frappe.model.add_child(doc, "items");
+
+										items.forEach(function (item) {
+											for (var key in item) {
+												if (Object.prototype.hasOwnProperty.call(item, key)) {
+													child[key] = item[key];
+												}
+											}
+										});
+										frappe.set_route("Form", "Delivery Note", doc.name);
+									});
+								},
+							});
+						},
+						() => {
+							// action to perform if No is selected
+						}
+					);
+				},
+				__("Create")
+			);
+		}
+	},
+
 	setup: (frm) => {
 		frm.set_query("to_employee", "assets", (doc) => {
 			return {
@@ -32,13 +96,16 @@ frappe.ui.form.on("Asset Movement", {
 				},
 			};
 		}),
-			frm.set_query("asset", "assets", () => {
-				return {
-					filters: {
-						status: ["not in", ["Draft"]],
-					},
-				};
-			});
+		frm.set_query("asset", "assets", () => {
+			return {
+				filters: {
+					status: ["not in", ["Draft"]],
+				},
+			};
+		});
+
+		set_cost_center_query(frm, "source_cost_center");
+		set_cost_center_query(frm, "target_cost_center");
 	},
 
 	onload: (frm) => {
@@ -90,22 +157,61 @@ frappe.ui.form.on("Asset Movement", {
 	},
 });
 
+function set_cost_center_query(frm, fieldname) {
+	frm.fields_dict["assets"].grid.get_field(fieldname).get_query = function (doc, cdt, cdn) {
+		return {
+			filters: {
+				company: frm.doc.company,
+				is_group: 0,
+			},
+		};
+	};
+}
+
 frappe.ui.form.on("Asset Movement Item", {
 	asset: function (frm, cdt, cdn) {
-		// on manual entry of an asset auto sets their source location / employee
-		const asset_name = locals[cdt][cdn].asset;
-		if (asset_name) {
-			frappe.db
-				.get_doc("Asset", asset_name)
-				.then((asset_doc) => {
-					if (asset_doc.location)
-						frappe.model.set_value(cdt, cdn, "source_location", asset_doc.location);
-					if (asset_doc.custodian)
-						frappe.model.set_value(cdt, cdn, "from_employee", asset_doc.custodian);
-				})
-				.catch((err) => {
-					console.log(err); // eslint-disable-line
-				});
-		}
+		frappe.db
+			.get_list("Accounting Dimension", {
+				fields: ["name"],
+			})
+			.then((fields) => {
+				const field_names = fields.map(
+					(field) => `source_${field.name.toLowerCase().replace(/ /g, "_")}`
+				);
+				const target_fields = fields.map(
+					(field) => `target_${field.name.toLowerCase().replace(/ /g, "_")}`
+				);
+
+				const asset_name = locals[cdt][cdn].asset;
+
+				if (asset_name) {
+					frappe.db.get_doc("Asset", asset_name).then((asset_doc) => {
+						if (asset_doc.location) {
+							frappe.model.set_value(cdt, cdn, "source_location", asset_doc.location);
+						}
+						if (asset_doc.custodian) {
+							frappe.model.set_value(cdt, cdn, "from_employee", asset_doc.custodian);
+						}
+						if (asset_doc.cost_center) {
+							frappe.model.set_value(cdt, cdn, "source_cost_center", asset_doc.cost_center);
+						}
+						if (frm.doc.purpose == "Issue" || frm.doc.purpose == "Reciept") {
+							target_fields.forEach((field) => {
+								const original_field = field.replace("target_", "");
+								if (asset_doc[original_field]) {
+									frappe.model.set_value(cdt, cdn, field, asset_doc[original_field]);
+								}
+							});
+							frappe.model.set_value(cdt, cdn, "target_cost_center", asset_doc.cost_center);
+						}
+						field_names.forEach((field) => {
+							const original_field = field.replace("source_", "");
+							if (asset_doc[original_field]) {
+								frappe.model.set_value(cdt, cdn, field, asset_doc[original_field]);
+							}
+						});
+					});
+				}
+			});
 	},
 });

--- a/assets/assets/doctype/asset_movement/asset_movement.json
+++ b/assets/assets/doctype/asset_movement/asset_movement.json
@@ -10,6 +10,7 @@
   "purpose",
   "column_break_4",
   "transaction_date",
+  "journal_entry",
   "section_break_10",
   "assets",
   "reference",
@@ -91,12 +92,19 @@
   {
    "fieldname": "column_break_9",
    "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:doc.docstatus==1",
+   "fieldname": "journal_entry",
+   "fieldtype": "Link",
+   "label": "Journal Entry",
+   "options": "Journal Entry"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-06-28 16:54:26.571083",
+ "modified": "2024-09-19 03:56:09.122360",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Movement",

--- a/assets/assets/doctype/asset_movement/asset_movement.py
+++ b/assets/assets/doctype/asset_movement/asset_movement.py
@@ -6,7 +6,10 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import get_link_to_form
+from frappe.utils.data import date_diff, getdate
 
+from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import get_accounting_dimensions
+from assets.assets.doctype.asset.depreciation import make_depreciation_entry
 from assets.assets.doctype.asset_activity.asset_activity import add_asset_activity
 
 
@@ -26,6 +29,7 @@ class AssetMovement(Document):
 		amended_from: DF.Link | None
 		assets: DF.Table[AssetMovementItem]
 		company: DF.Link
+		journal_entry: DF.Link | None
 		purpose: DF.Literal["", "Issue", "Receipt", "Transfer"]
 		reference_doctype: DF.Link | None
 		reference_name: DF.DynamicLink | None
@@ -36,6 +40,7 @@ class AssetMovement(Document):
 		self.validate_asset()
 		self.validate_location()
 		self.validate_employee()
+		self.validate_dep_schedule()
 
 	def validate_asset(self):
 		for d in self.assets:
@@ -134,15 +139,53 @@ class AssetMovement(Document):
 					)
 				)
 
+	def validate_dep_schedule(self):
+		for asset in self.assets:
+			if not frappe.db.exists("Asset Depreciation Schedule", {"asset": asset.asset}):
+				return
+
+			asset_depr_schedule_doc = frappe.get_doc("Asset Depreciation Schedule", {"asset": asset.asset})
+			transaction_date = getdate(self.transaction_date)
+
+			asset_depr_schedule_list = frappe.db.get_all(
+				"Depreciation Schedule",
+				filters={"parent": asset_depr_schedule_doc.name},
+				fields=[
+					"schedule_date",
+					"name",
+					"depreciation_amount",
+					"accumulated_depreciation_amount",
+					"journal_entry",
+				],
+				order_by="schedule_date",
+			)
+
+			next_schedule = None
+			for schedule in asset_depr_schedule_list:
+				if schedule["schedule_date"] >= transaction_date:
+					next_schedule = schedule
+					break
+			if next_schedule:
+				if next_schedule["journal_entry"]:
+					frappe.throw(_("Depreciation Entry of Transaction Date is already made"))
+
 	def on_submit(self):
-		self.set_latest_location_and_custodian_in_asset()
+		self.set_accounting_dimensions_and_custodian_in_asset()
+
+	def before_cancel(self):
+		self.sequence_cancel()
 
 	def on_cancel(self):
-		self.set_latest_location_and_custodian_in_asset()
+		self.set_accounting_dimensions_and_custodian_in_asset()
+		self.on_cancel_reverse_depreciation_schedule()
 
-	def set_latest_location_and_custodian_in_asset(self):
-		current_location, current_employee = "", ""
-		cond = "1=1"
+	def set_accounting_dimensions_and_custodian_in_asset(self):
+		fieldnames = get_accounting_dimensions(as_list=True)
+		target_dimension_fields = [f"target_{fieldname}" for fieldname in fieldnames]
+		field_mapping = {tf: tf.split("_", 1)[1] for tf in target_dimension_fields}
+		target_dimension_fields_str = (
+			", " + ", ".join(target_dimension_fields) if target_dimension_fields else ""
+		)
 
 		for d in self.assets:
 			args = {"asset": d.asset, "company": self.company}
@@ -151,28 +194,54 @@ class AssetMovement(Document):
 			# In case of cancellation it corresponds to previous latest document's location, employee
 			latest_movement_entry = frappe.db.sql(
 				f"""
-				SELECT asm_item.target_location, asm_item.to_employee
+				SELECT asm_item.target_location, asm_item.to_employee, asm_item.target_cost_center{target_dimension_fields_str}
 				FROM `tabAsset Movement Item` asm_item, `tabAsset Movement` asm
 				WHERE
 					asm_item.parent=asm.name and
 					asm_item.asset=%(asset)s and
 					asm.company=%(company)s and
-					asm.docstatus=1 and {cond}
+					asm.docstatus=1
 				ORDER BY
 					asm.transaction_date desc limit 1
 				""",
 				args,
+				as_dict=True,
 			)
 			if latest_movement_entry:
-				current_location = latest_movement_entry[0][0]
-				current_employee = latest_movement_entry[0][1]
+				current_location = latest_movement_entry[0]["target_location"]
+				current_employee = latest_movement_entry[0]["to_employee"]
+				target_cost_center = latest_movement_entry[0]["target_cost_center"]
+				current_values = {
+					field_mapping[tf]: latest_movement_entry[0][tf] for tf in target_dimension_fields
+				}
+			else:
+				current_location = current_employee = target_cost_center = ""
+				current_values = {field: "" for field in fieldnames}
 
 			frappe.db.set_value(
-				"Asset", d.asset, "location", current_location, update_modified=False
+				"Asset",
+				d.asset,
+				{
+					"location": current_location,
+					"custodian": current_employee,
+					"cost_center": target_cost_center,
+					**current_values,
+				},
+				update_modified=False,
 			)
-			frappe.db.set_value(
-				"Asset", d.asset, "custodian", current_employee, update_modified=False
-			)
+			if self.purpose == "Transfer" and frappe.db.exists(
+				"Asset Depreciation Schedule", {"asset": d.asset}
+			):
+				asset_depr_schedule_doc = frappe.get_doc("Asset Depreciation Schedule", {"asset": d.asset})
+				update_depreciation_schedule(d.asset, asset_depr_schedule_doc.name, self.transaction_date)
+				make_depreciation_entry(asset_depr_schedule_doc.name)
+
+				frappe.db.set_value(
+					"Asset Depreciation Schedule",
+					asset_depr_schedule_doc.name,
+					{"cost_center": target_cost_center, **current_values},
+					update_modified=True,
+				)
 
 			if current_location and current_employee:
 				add_asset_activity(
@@ -196,3 +265,427 @@ class AssetMovement(Document):
 						get_link_to_form("Employee", current_employee)
 					),
 				)
+
+	def on_cancel_reverse_depreciation_schedule(self):
+		transaction_date = getdate(self.transaction_date)
+		for d in self.assets:
+			asset_depr_schedule_list = frappe.db.get_list(
+				"Asset Depreciation Schedule", {"asset": d.asset}, pluck="name"
+			)
+			for asset_depr_schedule in asset_depr_schedule_list:
+				if not frappe.db.exists(
+					"Depreciation Schedule",
+					{"parent": asset_depr_schedule, "schedule_date": transaction_date},
+				):
+					break
+
+				depreciation_entry = get_depreciation_entry(asset_depr_schedule, transaction_date)
+				if not depreciation_entry:
+					break
+				try:
+					cancel_journal_entry(depreciation_entry["journal_entry"])
+					reverse_depreciation_entry(asset_depr_schedule, depreciation_entry, transaction_date)
+				except Exception as e:
+					frappe.throw(str(e))
+
+	def sequence_cancel(self):
+		asset_name_list = frappe.db.get_all(
+			"Asset Movement Item", filters={"parent": self.name}, pluck="asset"
+		)
+		for asset_name in asset_name_list:
+			asset_movement_items = frappe.db.get_all(
+				"Asset Movement Item", filters={"asset": asset_name}, fields=["parent as name"]
+			)
+			asset_movement_name_list = list(set(item["name"] for item in asset_movement_items))
+
+			if asset_movement_name_list:
+				asset_movement_values = frappe.db.get_all(
+					"Asset Movement",
+					filters={"name": ["in", asset_movement_name_list], "docstatus": 1},
+					fields=["name", "creation"],
+				)
+
+				if asset_movement_values:
+					asset_movement_values.sort(key=lambda x: x["creation"], reverse=True)
+					most_recent_record = asset_movement_values[0]
+
+					if self.name != most_recent_record["name"]:
+						frappe.throw("You can only cancel the most recent record.")
+
+
+def update_depreciation_schedule(asset_name, asset_depriciation_schedule_name, transaction_date):
+	transaction_date = getdate(transaction_date)
+	asset_available_for_use_date = frappe.db.get_value("Asset", asset_name, "available_for_use_date")
+
+	previous_schedule, next_schedule = find_previous_and_next_schedules(
+		asset_depriciation_schedule_name, transaction_date
+	)
+
+	if not (previous_schedule or next_schedule):
+		return
+
+	set_depreciation_schedule(
+		previous_schedule,
+		next_schedule,
+		asset_available_for_use_date,
+		transaction_date,
+		asset_depriciation_schedule_name,
+	)
+
+
+def find_previous_and_next_schedules(asset_depriciation_schedule_name, transaction_date):
+	asset_depr_schedule_list = get_asset_depr_schedule(asset_depriciation_schedule_name)
+	previous_schedule = None
+	next_schedule = None
+	for schedule in asset_depr_schedule_list:
+		schedule_date = schedule["schedule_date"]
+		if schedule_date == transaction_date:
+			return None, None
+		elif schedule_date < transaction_date:
+			previous_schedule = schedule
+		else:
+			next_schedule = schedule
+			break
+	return previous_schedule, next_schedule
+
+
+def get_asset_depr_schedule(asset_depriciation_schedule_name):
+	return frappe.db.get_all(
+		"Depreciation Schedule",
+		filters={"parent": asset_depriciation_schedule_name},
+		fields=[
+			"schedule_date",
+			"name",
+			"depreciation_amount",
+			"accumulated_depreciation_amount",
+			"journal_entry",
+		],
+		order_by="schedule_date",
+	)
+
+
+def set_depreciation_schedule(
+	previous_schedule,
+	next_schedule,
+	asset_available_for_use_date,
+	transaction_date,
+	asset_depriciation_schedule_name,
+):
+	(
+		dep_amount_for_today,
+		dep_amount_for_next_schedule,
+		accumulated_depreciation_amount,
+	) = calculate_depreciation_amounts(
+		previous_schedule, next_schedule, asset_available_for_use_date, transaction_date
+	)
+
+	if not dep_amount_for_today:
+		return
+
+	asset_depreciation_schedule = frappe.get_doc(
+		"Asset Depreciation Schedule", asset_depriciation_schedule_name
+	)
+	asset_depreciation_schedule.append(
+		"depreciation_schedule",
+		{
+			"schedule_date": transaction_date,
+			"depreciation_amount": dep_amount_for_today,
+			"accumulated_depreciation_amount": accumulated_depreciation_amount,
+		},
+	)
+	asset_depreciation_schedule.save()
+
+	if next_schedule:
+		frappe.db.set_value(
+			"Depreciation Schedule",
+			next_schedule["name"],
+			"depreciation_amount",
+			dep_amount_for_next_schedule,
+		)
+
+	update_asset_depr_schedule_index(asset_depriciation_schedule_name)
+
+
+def calculate_depreciation_amounts(
+	previous_schedule, next_schedule, asset_available_for_use_date, transaction_date
+):
+	if not next_schedule:
+		return None, None, None
+
+	if previous_schedule:
+		date_diff_between_schedule = date_diff(
+			next_schedule["schedule_date"], previous_schedule["schedule_date"]
+		)
+		date_difference = date_diff(transaction_date, previous_schedule["schedule_date"])
+	else:
+		date_diff_between_schedule = date_diff(next_schedule["schedule_date"], asset_available_for_use_date)
+		date_difference = date_diff(transaction_date, asset_available_for_use_date)
+
+	dep_amount_for_today = (
+		next_schedule["depreciation_amount"] / date_diff_between_schedule
+	) * date_difference
+	dep_amount_for_next_schedule = next_schedule["depreciation_amount"] - dep_amount_for_today
+	accumulated_depreciation_amount = (
+		previous_schedule["accumulated_depreciation_amount"] + dep_amount_for_today
+		if previous_schedule
+		else dep_amount_for_today
+	)
+
+	return dep_amount_for_today, dep_amount_for_next_schedule, accumulated_depreciation_amount
+
+
+def update_next_schedule(schedule_name, dep_amount_for_next_schedule):
+	frappe.db.set_value(
+		"Depreciation Schedule", schedule_name, "depreciation_amount", dep_amount_for_next_schedule
+	)
+
+
+def update_asset_depr_schedule_index(asset_depriciation_schedule_name):
+	updated_asset_depr_schedule = get_asset_depr_schedule(asset_depriciation_schedule_name)
+	for idx, schedule in enumerate(updated_asset_depr_schedule):
+		frappe.db.set_value("Depreciation Schedule", schedule["name"], "idx", idx + 1)
+
+
+def set_value_in_journal_entry(
+	asset_values,
+	fixed_asset_account,
+	asset_movement_child_data,
+	new_dimension_value,
+	old_dimension_value,
+	accumulated_depreciation_amount,
+):
+	print(asset_values.gross_purchase_amount - accumulated_depreciation_amount)
+	reference = {"reference_type": "Asset", "reference_name": asset_movement_child_data.asset}
+	if accumulated_depreciation_amount:
+		row1 = {
+			"account": fixed_asset_account,
+			"debit_in_account_currency": asset_values.gross_purchase_amount - accumulated_depreciation_amount,
+			"cost_center": asset_movement_child_data.target_cost_center,
+		}
+		row1.update(reference)
+		row1.update(new_dimension_value)
+		row2 = {
+			"account": fixed_asset_account,
+			"credit_in_account_currency": asset_values.gross_purchase_amount
+			- accumulated_depreciation_amount,
+			"cost_center": asset_movement_child_data.source_cost_center,
+		}
+		row2.update(reference)
+		row2.update(old_dimension_value)
+	else:
+		row1 = {
+			"account": fixed_asset_account,
+			"debit_in_account_currency": asset_values.total_asset_cost,
+			"cost_center": asset_movement_child_data.target_cost_center,
+		}
+		row1.update(reference)
+		row1.update(new_dimension_value)
+		row2 = {
+			"account": fixed_asset_account,
+			"credit_in_account_currency": asset_values.total_asset_cost,
+			"cost_center": asset_movement_child_data.source_cost_center,
+		}
+		row2.update(reference)
+		row2.update(old_dimension_value)
+	rows = [row1, row2]
+
+	return rows
+
+
+def get_depreciation_entry(schedule_name, transaction_date):
+	return frappe.db.get_value(
+		"Depreciation Schedule",
+		{"parent": schedule_name, "schedule_date": transaction_date},
+		[
+			"name",
+			"parent",
+			"schedule_date",
+			"depreciation_amount",
+			"accumulated_depreciation_amount",
+			"journal_entry",
+		],
+		as_dict=True,
+	)
+
+
+def cancel_journal_entry(journal_entry_name):
+	if journal_entry_name:
+		journal_entry_doc = frappe.get_doc("Journal Entry", journal_entry_name)
+		if journal_entry_doc.docstatus == 1:
+			journal_entry_doc.cancel()
+
+
+def reverse_depreciation_entry(asset_depr_schedule_name, depreciation_entry, transaction_date):
+	asset_depr_schedule = get_asset_depr_schedule(asset_depr_schedule_name)
+	previous_schedule, next_schedule = previous_and_next_schedules(asset_depr_schedule, transaction_date)
+	frappe.get_doc("Depreciation Schedule", depreciation_entry["name"]).cancel()
+	frappe.db.delete("Depreciation Schedule", depreciation_entry["name"])
+
+	set_depr_schedule_value(previous_schedule, next_schedule, depreciation_entry)
+	update_asset_depr_schedule_index(asset_depr_schedule_name)
+
+
+def previous_and_next_schedules(schedule_list, transaction_date):
+	previous_schedule = None
+	next_schedule = None
+	for schedule in schedule_list:
+		if schedule["schedule_date"] < transaction_date:
+			previous_schedule = schedule
+		elif schedule["schedule_date"] > transaction_date:
+			next_schedule = schedule
+			break
+	return previous_schedule, next_schedule
+
+
+def set_depr_schedule_value(previous_schedule, next_schedule, depreciation_entry):
+	if next_schedule:
+		new_dep_amount = next_schedule["depreciation_amount"] + depreciation_entry["depreciation_amount"]
+		frappe.db.set_value(
+			"Depreciation Schedule", next_schedule["name"], "depreciation_amount", new_dep_amount
+		)
+
+		if previous_schedule:
+			accumulated_depreciation_amount = (
+				previous_schedule["accumulated_depreciation_amount"] + new_dep_amount
+			)
+			frappe.db.set_value(
+				"Depreciation Schedule",
+				next_schedule["name"],
+				"accumulated_depreciation_amount",
+				accumulated_depreciation_amount,
+			)
+
+
+@frappe.whitelist()
+def make_asset_movement_entry(asset_movement_name, transaction_date, company):
+	frappe.has_permission("Journal Entry", throw=True)
+	print(type(transaction_date))
+	transaction_date = frappe.utils.getdate(transaction_date)
+	asset_movement_doc = frappe.get_doc("Asset Movement", asset_movement_name)
+
+	fieldnames = frappe.get_list("Accounting Dimension", pluck="fieldname")
+	child_rows = []
+	for asset in asset_movement_doc.assets:
+		asset_values = frappe.db.get_value("Asset", {"name": asset.asset}, "*")
+
+		fixed_asset_account = frappe.db.get_value(
+			"Asset Category Account",
+			{"parent": asset_values.asset_category, "company_name": asset_values.company},
+			"fixed_asset_account",
+		)
+		asset_depr_schedule = frappe.db.get_all(
+			"Asset Depreciation Schedule", {"asset": asset.asset, "docstatus": 1}, pluck="name"
+		)
+		asset_movement_child_data = frappe.db.get_value(
+			"Asset Movement Item", {"parent": asset_movement_name, "asset": asset.asset}, "*", as_dict=True
+		)
+
+		old_dimension_value = {
+			fieldname: asset_movement_child_data.get("from_" + fieldname) for fieldname in fieldnames
+		}
+		new_dimension_value = {
+			fieldname: asset_movement_child_data.get("target_" + fieldname) for fieldname in fieldnames
+		}
+
+		if asset_values.calculate_depreciation and asset_depr_schedule:
+			for schedule in asset_depr_schedule:
+				print(schedule, transaction_date)
+				accumulated_depreciation_amount = frappe.db.get_value(
+					"Depreciation Schedule",
+					{"parent": schedule, "schedule_date": transaction_date},
+					"accumulated_depreciation_amount",
+				)
+				print(accumulated_depreciation_amount)
+				dep_row = set_value_in_journal_entry(
+					asset_values,
+					fixed_asset_account,
+					asset_movement_child_data,
+					new_dimension_value,
+					old_dimension_value,
+					accumulated_depreciation_amount,
+				)
+				child_rows += dep_row
+		else:
+			no_dep_row = set_value_in_journal_entry(
+				asset_values,
+				fixed_asset_account,
+				asset_movement_child_data,
+				new_dimension_value,
+				old_dimension_value,
+				None,
+			)
+			child_rows += no_dep_row
+
+	doc = frappe.get_doc(
+		{
+			"doctype": "Journal Entry",
+			"voucher_type": "Journal Entry",
+			"posting_date": transaction_date,
+			"company": company,
+			"accounts": child_rows,
+			"remark": f"Asset Movement Entry against {asset_movement_name}",
+		}
+	)
+	doc.save()
+	doc.submit()
+	asset_movement_doc.db_set("journal_entry", doc.name)
+
+	return asset_movement_doc
+
+
+@frappe.whitelist()
+def make_delivery_note(**kwargs):
+	transaction_date = getdate(kwargs.get("transaction_date"))
+	asset_movement_item_list = frappe.db.get_all("Asset Movement Item", {"parent": kwargs.get("name")}, ["*"])
+
+	fieldnames = frappe.get_list("Accounting Dimension", pluck="fieldname")
+
+	asset_names = [item.asset for item in asset_movement_item_list]
+	assets_info = frappe.db.get_all(
+		"Asset",
+		filters={"name": ["in", asset_names]},
+		fields=["name", "item_code", "asset_quantity"]
+	)
+
+	item_codes = [asset["item_code"] for asset in assets_info]
+	item_details = frappe.db.get_all(
+		"Item",
+		filters={"item_code": ["in", item_codes]},
+		fields=["item_code", "item_name", "stock_uom"]
+	)
+
+	assets_info_dict = {asset["name"]: asset for asset in assets_info}
+	item_details_dict = {item["item_code"]: item for item in item_details}
+
+	delivery_note_item_rows = []
+
+	for item in asset_movement_item_list:
+		asset_info = assets_info_dict.get(item.asset)
+		item_info = item_details_dict.get(asset_info["item_code"])
+
+		asset_schedule = frappe.db.get_all("Asset Depreciation Schedule", {"asset": item.asset}, pluck="name")
+
+		depreciation_data = frappe.db.get_all(
+			"Depreciation Schedule",
+			filters={"parent": ["in", asset_schedule], "schedule_date": transaction_date},
+			fields=["parent", "accumulated_depreciation_amount"]
+		)
+
+		depreciation_dict = {dep["parent"]: dep["accumulated_depreciation_amount"] for dep in depreciation_data}
+
+		for schedule in asset_schedule:
+			accumulated_depreciation = depreciation_dict.get(schedule)
+
+			old_dimension_value = {
+				"item_code": asset_info["item_code"],
+				"rate": accumulated_depreciation or 0,
+				"item_name": item_info["item_name"],
+				"uom": item_info["stock_uom"],
+				"qty": asset_info["asset_quantity"]
+			}
+
+			for fieldname in fieldnames:
+				old_dimension_value[fieldname] = item.get("source_" + fieldname)
+			delivery_note_item_rows.append(old_dimension_value)
+
+	return delivery_note_item_rows

--- a/assets/assets/doctype/asset_movement_item/asset_movement_item.json
+++ b/assets/assets/doctype/asset_movement_item/asset_movement_item.json
@@ -11,7 +11,13 @@
   "column_break_2",
   "asset_name",
   "target_location",
-  "to_employee"
+  "to_employee",
+  "accounting_dimension_source_section",
+  "source_cost_center",
+  "source_dimension_col_break",
+  "accounting_dimension_target_section",
+  "target_cost_center",
+  "target_dimension_col_break"
  ],
  "fields": [
   {
@@ -70,10 +76,40 @@
    "label": "Company",
    "options": "Company",
    "read_only": 1
-  }
- ],
+},
+{
+ "fieldname": "accounting_dimension_source_section",
+ "fieldtype": "Section Break",
+ "label": "Accounting Dimension (Source)"
+},
+{
+ "fieldname": "accounting_dimension_target_section",
+ "fieldtype": "Section Break",
+ "label": "Accounting Dimension (Target)"
+},
+{
+ "fieldname": "target_cost_center",
+ "fieldtype": "Link",
+ "label": "Target Cost Center",
+ "options": "Cost Center"
+},
+{
+ "fieldname": "source_dimension_col_break",
+ "fieldtype": "Column Break"
+},
+{
+ "fieldname": "target_dimension_col_break",
+ "fieldtype": "Column Break"
+},
+{
+ "fieldname": "source_cost_center",
+ "fieldtype": "Link",
+ "label": "Source Cost Center",
+ "options": "Cost Center"
+}
+],
  "istable": 1,
- "modified": "2019-10-09 15:59:08.265141",
+ "modified": "2024-09-20 02:44:54.216537",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Movement Item",

--- a/assets/assets/doctype/asset_movement_item/asset_movement_item.py
+++ b/assets/assets/doctype/asset_movement_item/asset_movement_item.py
@@ -22,7 +22,9 @@ class AssetMovementItem(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
+		source_cost_center: DF.Link | None
 		source_location: DF.Link | None
+		target_cost_center: DF.Link | None
 		target_location: DF.Link | None
 		to_employee: DF.Link | None
 	# end: auto-generated types


### PR DESCRIPTION
1. Add accounting dimension in the asset movement doctype
2. Source dimension should auto fetch and target dimension should be added manually
3. Location should remain same in case of issue, while receipt location will be updated and in transfer everything can be updated
4. Journal entry should be passed on transfer to update the accounting dimension and reflect in financial statement as well
5. On submit of movement asset depreciation schedule is created and reversed on cancel
6. Sequence cancel of asset movement on creation