### PR TITLE
test:Test-cases-for-the-multiple-group-asset-cancelation

### DIFF
--- a/assets/assets/doctype/asset/test_asset.py
+++ b/assets/assets/doctype/asset/test_asset.py
@@ -1947,119 +1947,20 @@ class TestAsset(AssetSetup):
 
 		self.assertRaises(frappe.MandatoryError, asset.save)
 	
-	# TC_FA_135
-	def test_create_pi_and_debit_note_TC_FA_135(self):
-		"""
-		Function to create and submit a Purchase Order and Purchase Invoice,
-		then create a Debit Note/Return when an asset is auto-created.
-		"""
-		company = "_Test Company"
-		supplier = "_Test Supplier"
-		item_code = "Test_USB_Wire"
-		qty, rate, warehouse = 1, 500, "_Test Warehouse - _TC"
-		required_by_date = nowdate()
-
-		# Ensure prerequisites exist
-		if not frappe.db.exists("Company", company):
-			create_child_company()
-
-		if not frappe.db.exists("Item", item_code):
-			frappe.get_doc({
-				"doctype": "Item",
-				"item_code": item_code,
-				"item_name": item_code,
-				"is_stock_item": 0,
-				"is_fixed_asset": 1,
-				"gst_hsn_code": "01011010",
-				"auto_create_assets": 1,
-				"asset_category": "Test_Category",
-				"asset_naming_series": "ACC-ASS-.YYYY.-"
-			}).insert()
-
-		# Create and submit Purchase Invoice
-		pi = frappe.get_doc({
-			"doctype": "Purchase Invoice",
-			"company": company,
-			"supplier": supplier,
-			"update_stock": 1,  # Update stock
-			"posting_date": nowdate(),
-			"items": [
-				{
-					"item_code": item_code,
-					"qty": qty,
-					"rate": rate,
-					"location": "Test Location",  # Linking the correct warehouse
-					"asset_location": "Test Location",  # Specifying asset location
-					"expense_account": "_Test Account Cost for Goods Sold - _TC"
-				}
-			]
-		})
-		pi.insert()
-		pi.submit()
-		frappe.db.commit()
-
-		# Create Debit Note / Return
-		debit_note = frappe.get_doc({
-			"doctype": "Purchase Invoice",
-			"company": company,
-			"supplier": supplier,
-			"is_return": 1,  # Mark as a return
-			"return_against": pi.name,  # Link to original Purchase Invoice
-			"items": [
-				{
-					"item_code": item_code,
-					"qty": -qty,  # Negative quantity to indicate return
-					"rate": rate,
-					"location": "Test Location",
-					"asset_location": "Test Location",
-					"expense_account": "_Test Account Cost for Goods Sold - _TC"
-				}
-			]
-		})
-		debit_note.insert()
-		debit_note.submit()
-		frappe.db.commit()
-	
-	# TC_FA_136
-	def test_create_pi_asset_and_createdebitnote__TC_FA_136(self):
-		"""
-		Function to create and submit a Purchase Order and Purchase Invoice,
-		then attempt to create a Debit Note/Return after asset submission.
-		"""
-		company = "_Test Company"
-		supplier = "_Test Supplier"
-		item_code = "Test_USB_Wire"
-		qty, rate, warehouse = 1, 500, "_Test Warehouse - _TC"
-		required_by_date = nowdate()
-
-		# Ensure prerequisites exist
-		if not frappe.db.exists("Company", company):
-			create_child_company()
-
-		if not frappe.db.exists("Item", item_code):
-			frappe.get_doc({
-				"doctype": "Item",
-				"item_code": item_code,
-				"item_name": item_code,
-				"is_stock_item": 0,
-				"is_fixed_asset": 1,
-				"gst_hsn_code": "01011010",
-				"auto_create_assets": 1,
-				"asset_category": "Test_Category",
-				"asset_naming_series": "ACC-ASS-.YYYY.-"
-			}).insert()
-
-		# Create and submit Purchase Invoice
+	def create_purchase_invoice(self, company, supplier, item_code, qty, rate, is_return=False, return_against=None):
+		"""Creates and submits a Purchase Invoice, optionally as a return."""
 		pi = frappe.get_doc({
 			"doctype": "Purchase Invoice",
 			"company": company,
 			"supplier": supplier,
 			"update_stock": 1,
 			"posting_date": nowdate(),
+			"is_return": is_return,
+			"return_against": return_against,
 			"items": [
 				{
 					"item_code": item_code,
-					"qty": qty,
+					"qty": -qty if is_return else qty,
 					"rate": rate,
 					"location": "Test Location",
 					"asset_location": "Test Location",
@@ -2069,31 +1970,37 @@ class TestAsset(AssetSetup):
 		})
 		pi.insert()
 		pi.submit()
-		frappe.db.commit()
+		return pi
 
-		# Fetch the auto-created asset
+	def handle_asset_submission(self, item_code):
+		"""Fetches and submits an auto-created asset."""
 		asset = frappe.get_list("Asset", filters={"item_code": item_code}, fields=["name", "docstatus"])
 		if asset:
 			asset_doc = frappe.get_doc("Asset", asset[0].name)
 			asset_doc.available_for_use_date = nowdate()
-			asset_doc.submit()  # Submit the asset
-			frappe.db.commit()
+			asset_doc.submit()
+			return asset_doc
+		return None
 
-			# Cancel the asset before proceeding with the return
+	def cancel_asset(self, asset_doc):
+		"""Cancels an asset document."""
+		if asset_doc:
 			asset_doc.cancel()
-			frappe.db.commit()
-
-		# Create the Debit Note / Return
-		debit_note = frappe.get_doc({
+	
+	def create_purchase_invoice(self, company, supplier, item_code, qty, rate, is_return=False, return_against=None):
+		"""Creates and submits a Purchase Invoice, optionally as a return."""
+		pi = frappe.get_doc({
 			"doctype": "Purchase Invoice",
 			"company": company,
 			"supplier": supplier,
-			"is_return": 1,
-			"return_against": pi.name,
+			"update_stock": 1,
+			"posting_date": nowdate(),
+			"is_return": is_return,
+			"return_against": return_against,
 			"items": [
 				{
 					"item_code": item_code,
-					"qty": -qty,
+					"qty": -qty if is_return else qty,
 					"rate": rate,
 					"location": "Test Location",
 					"asset_location": "Test Location",
@@ -2101,10 +2008,74 @@ class TestAsset(AssetSetup):
 				}
 			]
 		})
-		debit_note.insert()
-		debit_note.submit()
-		frappe.db.commit()
-	
+		pi.insert()
+		pi.submit()
+		return pi
+
+	def handle_asset_submission(self, item_code):
+		"""Fetches and submits an auto-created asset."""
+		asset = frappe.get_list("Asset", filters={"item_code": item_code}, fields=["name", "docstatus"])
+		if asset:
+			asset_doc = frappe.get_doc("Asset", asset[0].name)
+			asset_doc.available_for_use_date = nowdate()
+			asset_doc.submit()
+			return asset_doc
+		return None
+
+	def cancel_asset(self, asset_doc):
+		"""Cancels an asset document."""
+		if asset_doc:
+			asset_doc.cancel()
+			
+	# TC_FA_135
+	def test_create_pi_and_debit_note_TC_FA_135(self):
+		"""Test case to create a PI and a Debit Note when an asset is auto-created."""
+		company, supplier, item_code, qty, rate = "_Test Company", "_Test Supplier", "Test_USB_Wire", 1, 500
+
+		if not frappe.db.exists("Company", company):
+			self.create_child_company()
+		
+		if not frappe.db.exists("Item", item_code):
+			frappe.get_doc({
+				"doctype": "Item",
+				"item_code": item_code,
+				"item_name": item_code,
+				"is_stock_item": 0,
+				"is_fixed_asset": 1,
+				"gst_hsn_code": "01011010",
+				"auto_create_assets": 1,
+				"asset_category": "Test_Category",
+				"asset_naming_series": "ACC-ASS-.YYYY.-"
+			}).insert()
+		
+		pi = self.create_purchase_invoice(company, supplier, item_code, qty, rate)
+		self.create_purchase_invoice(company, supplier, item_code, qty, rate, is_return=True, return_against=pi.name)
+
+	# TC_FA_136
+	def test_create_pi_asset_and_createdebitnote_TC_FA_136(self):  # FIXED: Added `self`
+		"""Test case to create a PI, submit an asset, cancel it, and then create a Debit Note."""
+		company, supplier, item_code, qty, rate = "_Test Company", "_Test Supplier", "Test_USB_Wire", 1, 500
+		
+		if not frappe.db.exists("Company", company):
+			self.create_child_company()
+		
+		if not frappe.db.exists("Item", item_code):
+			frappe.get_doc({
+				"doctype": "Item",
+				"item_code": item_code,
+				"item_name": item_code,
+				"is_stock_item": 0,
+				"is_fixed_asset": 1,
+				"gst_hsn_code": "01011010",
+				"auto_create_assets": 1,
+				"asset_category": "Test_Category",
+				"asset_naming_series": "ACC-ASS-.YYYY.-"
+			}).insert()
+		
+		pi = self.create_purchase_invoice(company, supplier, item_code, qty, rate)
+		asset_doc = self.handle_asset_submission(item_code)
+		self.cancel_asset(asset_doc)
+		self.create_purchase_invoice(company, supplier, item_code, qty, rate, is_return=True, return_against=pi.name)
 
 	def test_pr_or_pi_mandatory_if_not_existing_asset(self):
 		"""Tests if either PI or PR is present if CWIP is enabled and is_existing_asset=0."""

--- a/assets/assets/doctype/asset/test_asset.py
+++ b/assets/assets/doctype/asset/test_asset.py
@@ -1947,6 +1947,163 @@ class TestAsset(AssetSetup):
 
 		self.assertRaises(frappe.MandatoryError, asset.save)
 	
+	# TC_FA_135
+	def test_create_pi_and_debit_note_TC_FA_135(self):
+		"""
+		Function to create and submit a Purchase Order and Purchase Invoice,
+		then create a Debit Note/Return when an asset is auto-created.
+		"""
+		company = "_Test Company"
+		supplier = "_Test Supplier"
+		item_code = "Test_USB_Wire"
+		qty, rate, warehouse = 1, 500, "_Test Warehouse - _TC"
+		required_by_date = nowdate()
+
+		# Ensure prerequisites exist
+		if not frappe.db.exists("Company", company):
+			create_child_company()
+
+		if not frappe.db.exists("Item", item_code):
+			frappe.get_doc({
+				"doctype": "Item",
+				"item_code": item_code,
+				"item_name": item_code,
+				"is_stock_item": 0,
+				"is_fixed_asset": 1,
+				"gst_hsn_code": "01011010",
+				"auto_create_assets": 1,
+				"asset_category": "Test_Category",
+				"asset_naming_series": "ACC-ASS-.YYYY.-"
+			}).insert()
+
+		# Create and submit Purchase Invoice
+		pi = frappe.get_doc({
+			"doctype": "Purchase Invoice",
+			"company": company,
+			"supplier": supplier,
+			"update_stock": 1,  # Update stock
+			"posting_date": nowdate(),
+			"items": [
+				{
+					"item_code": item_code,
+					"qty": qty,
+					"rate": rate,
+					"location": "Test Location",  # Linking the correct warehouse
+					"asset_location": "Test Location",  # Specifying asset location
+					"expense_account": "_Test Account Cost for Goods Sold - _TC"
+				}
+			]
+		})
+		pi.insert()
+		pi.submit()
+		frappe.db.commit()
+
+		# Create Debit Note / Return
+		debit_note = frappe.get_doc({
+			"doctype": "Purchase Invoice",
+			"company": company,
+			"supplier": supplier,
+			"is_return": 1,  # Mark as a return
+			"return_against": pi.name,  # Link to original Purchase Invoice
+			"items": [
+				{
+					"item_code": item_code,
+					"qty": -qty,  # Negative quantity to indicate return
+					"rate": rate,
+					"location": "Test Location",
+					"asset_location": "Test Location",
+					"expense_account": "_Test Account Cost for Goods Sold - _TC"
+				}
+			]
+		})
+		debit_note.insert()
+		debit_note.submit()
+		frappe.db.commit()
+	
+	# TC_FA_136
+	def test_create_pi_asset_and_createdebitnote__TC_FA_136(self):
+		"""
+		Function to create and submit a Purchase Order and Purchase Invoice,
+		then attempt to create a Debit Note/Return after asset submission.
+		"""
+		company = "_Test Company"
+		supplier = "_Test Supplier"
+		item_code = "Test_USB_Wire"
+		qty, rate, warehouse = 1, 500, "_Test Warehouse - _TC"
+		required_by_date = nowdate()
+
+		# Ensure prerequisites exist
+		if not frappe.db.exists("Company", company):
+			create_child_company()
+
+		if not frappe.db.exists("Item", item_code):
+			frappe.get_doc({
+				"doctype": "Item",
+				"item_code": item_code,
+				"item_name": item_code,
+				"is_stock_item": 0,
+				"is_fixed_asset": 1,
+				"gst_hsn_code": "01011010",
+				"auto_create_assets": 1,
+				"asset_category": "Test_Category",
+				"asset_naming_series": "ACC-ASS-.YYYY.-"
+			}).insert()
+
+		# Create and submit Purchase Invoice
+		pi = frappe.get_doc({
+			"doctype": "Purchase Invoice",
+			"company": company,
+			"supplier": supplier,
+			"update_stock": 1,
+			"posting_date": nowdate(),
+			"items": [
+				{
+					"item_code": item_code,
+					"qty": qty,
+					"rate": rate,
+					"location": "Test Location",
+					"asset_location": "Test Location",
+					"expense_account": "_Test Account Cost for Goods Sold - _TC"
+				}
+			]
+		})
+		pi.insert()
+		pi.submit()
+		frappe.db.commit()
+
+		# Fetch the auto-created asset
+		asset = frappe.get_list("Asset", filters={"item_code": item_code}, fields=["name", "docstatus"])
+		if asset:
+			asset_doc = frappe.get_doc("Asset", asset[0].name)
+			asset_doc.available_for_use_date = nowdate()
+			asset_doc.submit()  # Submit the asset
+			frappe.db.commit()
+
+			# Cancel the asset before proceeding with the return
+			asset_doc.cancel()
+			frappe.db.commit()
+
+		# Create the Debit Note / Return
+		debit_note = frappe.get_doc({
+			"doctype": "Purchase Invoice",
+			"company": company,
+			"supplier": supplier,
+			"is_return": 1,
+			"return_against": pi.name,
+			"items": [
+				{
+					"item_code": item_code,
+					"qty": -qty,
+					"rate": rate,
+					"location": "Test Location",
+					"asset_location": "Test Location",
+					"expense_account": "_Test Account Cost for Goods Sold - _TC"
+				}
+			]
+		})
+		debit_note.insert()
+		debit_note.submit()
+		frappe.db.commit()
 	
 
 	def test_pr_or_pi_mandatory_if_not_existing_asset(self):

--- a/assets/assets/doctype/asset_movement/test_asset_movement.py
+++ b/assets/assets/doctype/asset_movement/test_asset_movement.py
@@ -2289,6 +2289,199 @@ class TestAssetMovement(unittest.TestCase):
 		asset_movement.cancel()
 		frappe.db.commit()
 
+	# TC_FA_153
+	def test_multiple_asset_movement_with_purposetype_transfer_issue_cancel_TC_FA_153(self):
+		company = "_Test Company"
+		employees = ["_T-Employee-00001", "_T-Employee-00002"]
+		items = ["Test_item_01", "Test_item_02"]
+		assets = []
+
+		# Ensure prerequisites exist
+		if not frappe.db.exists("Company", company):
+			create_child_company()
+
+		for emp_id in employees:
+			if not frappe.db.exists("Employee", emp_id):
+				frappe.get_doc({
+					"doctype": "Employee",
+					"employee_name": emp_id,
+					"first_name": emp_id,
+					"gender": "Male",
+					"date_of_birth": "1990-01-01",
+					"date_of_joining": "2023-01-01",
+					"status": "Active",
+					"company": company
+				}).insert()
+
+		for item_code, employee_id in zip(items, employees):
+			# Create item if it doesn't exist
+			if not frappe.db.exists("Item", item_code):
+				frappe.get_doc({
+					"doctype": "Item",
+					"item_code": item_code,
+					"item_name": item_code,
+					"gst_hsn_code": "01011010",
+					"is_stock_item": 0,
+					"is_fixed_asset": 1,
+					"auto_create_assets": 1,
+					"asset_category": "Test_Category"
+				}).insert()
+
+			# Create asset
+			asset = frappe.get_doc({
+				"doctype": "Asset",
+				"company": company,
+				"item_code": item_code,
+				"asset_name": item_code,
+				"asset_category": "Test_Category",
+				"location": "Test Location",
+				"is_existing_asset": 1,
+				"custodian": employee_id,
+				"owner": "Company",
+				"available_for_use_date": "2024-04-02",
+				"gross_purchase_amount": 8000,
+				"total_asset": 8000,
+				"asset_quantity": 1,
+				"purchase_date": "2024-04-01"
+			}).insert()
+			asset.submit()
+			assets.append(asset.name)
+
+		frappe.db.commit()
+
+		# Create Issue Type Asset Movement
+		issue_movement = frappe.get_doc({
+			"doctype": "Asset Movement",
+			"company": company,
+			"purpose": "Issue",
+			"assets": [{
+				"asset": asset,
+				"source_location": "Test Location",
+				"to_employee": employee_id,
+				"source_cost_center": "_Test Cost Center - _TC"
+			} for asset, employee_id in zip(assets, employees)]
+		})
+		issue_movement.insert()
+		issue_movement.submit()
+		frappe.db.commit()
+
+		# Cancel the Issue Movement
+		issue_movement.cancel()
+		frappe.db.commit()
+
+		# Create Transfer Type Asset Movement using the same assets
+		transfer_movement = frappe.get_doc({
+			"doctype": "Asset Movement",
+			"company": company,
+			"purpose": "Transfer",
+			"assets": [{
+				"asset": asset,
+				"source_location": "Test Location",
+				"target_location": "Field 1",
+			} for asset in assets]
+		})
+		transfer_movement.insert()
+		transfer_movement.submit()
+		frappe.db.commit()
+
+		# Cancel the Transfer Movement
+		transfer_movement.cancel()
+		frappe.db.commit()
+
+	# TC_FA_154
+	def test_single_asset_movement_with_purposetype_transfer_issue_cancel_TC_FA_154(self):
+		company = "_Test Company"
+		employee = "_T-Employee-00001"
+		item_code = "Test_item_01"
+		asset = None
+
+		# Ensure prerequisites exist
+		if not frappe.db.exists("Company", company):
+			create_child_company()
+
+		if not frappe.db.exists("Employee", employee):
+			frappe.get_doc({
+				"doctype": "Employee",
+				"employee_name": employee,
+				"first_name": employee,
+				"gender": "Male",
+				"date_of_birth": "1990-01-01",
+				"date_of_joining": "2023-01-01",
+				"status": "Active",
+				"company": company
+			}).insert()
+
+		# Create item if it doesn't exist
+		if not frappe.db.exists("Item", item_code):
+			frappe.get_doc({
+				"doctype": "Item",
+				"item_code": item_code,
+				"item_name": item_code,
+				"gst_hsn_code": "01011010",
+				"is_stock_item": 0,
+				"is_fixed_asset": 1,
+				"auto_create_assets": 1,
+				"asset_category": "Test_Category"
+			}).insert()
+
+		# Create asset
+		asset = frappe.get_doc({
+			"doctype": "Asset",
+			"company": company,
+			"item_code": item_code,
+			"asset_name": item_code,
+			"asset_category": "Test_Category",
+			"location": "Test Location",
+			"is_existing_asset": 1,
+			"custodian": employee,
+			"owner": "Company",
+			"available_for_use_date": "2024-04-02",
+			"gross_purchase_amount": 8000,
+			"total_asset": 8000,
+			"asset_quantity": 1,
+			"purchase_date": "2024-04-01"
+		}).insert()
+		asset.submit()
+		frappe.db.commit()
+
+		# Create Issue Type Asset Movement
+		issue_movement = frappe.get_doc({
+			"doctype": "Asset Movement",
+			"company": company,
+			"purpose": "Issue",
+			"assets": [{
+				"asset": asset.name,
+				"source_location": "Test Location",
+				"to_employee": employee,
+				"source_cost_center": "_Test Cost Center - _TC"
+			}]
+		})
+		issue_movement.insert()
+		issue_movement.submit()
+		frappe.db.commit()
+
+		# Cancel the Issue Movement
+		issue_movement.cancel()
+		frappe.db.commit()
+
+		# Create Transfer Type Asset Movement
+		transfer_movement = frappe.get_doc({
+			"doctype": "Asset Movement",
+			"company": company,
+			"purpose": "Transfer",
+			"assets": [{
+				"asset": asset.name,
+				"source_location": "Test Location",
+				"target_location": "Field 1"
+			}]
+		})
+		transfer_movement.insert()
+		transfer_movement.submit()
+		frappe.db.commit()
+
+		# Cancel the Transfer Movement
+		transfer_movement.cancel()
+		frappe.db.commit()
 
 
 

--- a/assets/assets/doctype/asset_movement/test_asset_movement.py
+++ b/assets/assets/doctype/asset_movement/test_asset_movement.py
@@ -1991,7 +1991,6 @@ class TestAssetMovement(unittest.TestCase):
 			asset.submit()
 			assets.append(asset.name)
 
-		frappe.db.commit()
 
 		# Create Issue Type Asset Movement
 		issue_movement = frappe.get_doc({
@@ -2007,11 +2006,9 @@ class TestAssetMovement(unittest.TestCase):
 		})
 		issue_movement.insert()
 		issue_movement.submit()
-		frappe.db.commit()
 
 		# Cancel the Issue Movement
 		issue_movement.cancel()
-		frappe.db.commit()
 
 		# Create Transfer Type Asset Movement using the same assets
 		transfer_movement = frappe.get_doc({
@@ -2027,7 +2024,6 @@ class TestAssetMovement(unittest.TestCase):
 		})
 		transfer_movement.insert()
 		transfer_movement.submit()
-		frappe.db.commit()
 
 	# TC_FA_150
 	def test_single_asset_movement_with_purposetype_transfer_issue_150(self):
@@ -2082,8 +2078,6 @@ class TestAssetMovement(unittest.TestCase):
 		}).insert()
 		asset.submit()
 
-		frappe.db.commit()
-
 		# Create Issue Type Asset Movement (Single Asset Tagged)
 		issue_movement = frappe.get_doc({
 			"doctype": "Asset Movement",
@@ -2098,11 +2092,9 @@ class TestAssetMovement(unittest.TestCase):
 		})
 		issue_movement.insert()
 		issue_movement.submit()
-		frappe.db.commit()
 
 		# Cancel the Issue Movement
 		issue_movement.cancel()
-		frappe.db.commit()
 
 		# Create Transfer Type Asset Movement (Same Single Asset)
 		transfer_movement = frappe.get_doc({
@@ -2118,7 +2110,6 @@ class TestAssetMovement(unittest.TestCase):
 		})
 		transfer_movement.insert()
 		transfer_movement.submit()
-		frappe.db.commit()
 
 	# TC_FA_151
 	def test_multiple_asset_movement_with_purposetype_transfer_issue_151(self):
@@ -2173,8 +2164,6 @@ class TestAssetMovement(unittest.TestCase):
 		}).insert()
 		asset.submit()
 
-		frappe.db.commit()
-
 		# Create Issue Type Asset Movement (Single Asset Tagged)
 		issue_movement = frappe.get_doc({
 			"doctype": "Asset Movement",
@@ -2189,11 +2178,9 @@ class TestAssetMovement(unittest.TestCase):
 		})
 		issue_movement.insert()
 		issue_movement.submit()
-		frappe.db.commit()
 
 		# Cancel the Issue Movement
 		issue_movement.cancel()
-		frappe.db.commit()
 
 		# Create Transfer Type Asset Movement (Same Single Asset)
 		transfer_movement = frappe.get_doc({
@@ -2209,11 +2196,9 @@ class TestAssetMovement(unittest.TestCase):
 		})
 		transfer_movement.insert()
 		transfer_movement.submit()
-		frappe.db.commit()
 
 		# Cancel the Issue Movement
 		transfer_movement.cancel()
-		frappe.db.commit()
 
 	# TC_FA_152
 	def test_single_asset_movement_with_purposetype_transfer_issue_152(self):
@@ -2267,7 +2252,6 @@ class TestAssetMovement(unittest.TestCase):
 			"purchase_date": "2024-04-01"
 		}).insert()
 		asset.submit()
-		frappe.db.commit()
 
 		# Create a single asset movement (either Issue or Transfer)
 		asset_movement = frappe.get_doc({
@@ -2283,11 +2267,9 @@ class TestAssetMovement(unittest.TestCase):
 		})
 		asset_movement.insert()
 		asset_movement.submit()
-		frappe.db.commit()
 
 		# Cancel the movement
 		asset_movement.cancel()
-		frappe.db.commit()
 
 	# TC_FA_153
 	def test_multiple_asset_movement_with_purposetype_transfer_issue_cancel_TC_FA_153(self):
@@ -2347,7 +2329,6 @@ class TestAssetMovement(unittest.TestCase):
 			asset.submit()
 			assets.append(asset.name)
 
-		frappe.db.commit()
 
 		# Create Issue Type Asset Movement
 		issue_movement = frappe.get_doc({
@@ -2363,11 +2344,9 @@ class TestAssetMovement(unittest.TestCase):
 		})
 		issue_movement.insert()
 		issue_movement.submit()
-		frappe.db.commit()
 
 		# Cancel the Issue Movement
 		issue_movement.cancel()
-		frappe.db.commit()
 
 		# Create Transfer Type Asset Movement using the same assets
 		transfer_movement = frappe.get_doc({
@@ -2382,11 +2361,9 @@ class TestAssetMovement(unittest.TestCase):
 		})
 		transfer_movement.insert()
 		transfer_movement.submit()
-		frappe.db.commit()
 
 		# Cancel the Transfer Movement
 		transfer_movement.cancel()
-		frappe.db.commit()
 
 	# TC_FA_154
 	def test_single_asset_movement_with_purposetype_transfer_issue_cancel_TC_FA_154(self):
@@ -2442,7 +2419,6 @@ class TestAssetMovement(unittest.TestCase):
 			"purchase_date": "2024-04-01"
 		}).insert()
 		asset.submit()
-		frappe.db.commit()
 
 		# Create Issue Type Asset Movement
 		issue_movement = frappe.get_doc({
@@ -2458,11 +2434,9 @@ class TestAssetMovement(unittest.TestCase):
 		})
 		issue_movement.insert()
 		issue_movement.submit()
-		frappe.db.commit()
 
 		# Cancel the Issue Movement
 		issue_movement.cancel()
-		frappe.db.commit()
 
 		# Create Transfer Type Asset Movement
 		transfer_movement = frappe.get_doc({
@@ -2477,11 +2451,9 @@ class TestAssetMovement(unittest.TestCase):
 		})
 		transfer_movement.insert()
 		transfer_movement.submit()
-		frappe.db.commit()
 
 		# Cancel the Transfer Movement
 		transfer_movement.cancel()
-		frappe.db.commit()
 
 
 

--- a/assets/assets/doctype/asset_movement/test_asset_movement.py
+++ b/assets/assets/doctype/asset_movement/test_asset_movement.py
@@ -1932,6 +1932,366 @@ class TestAssetMovement(unittest.TestCase):
 		# Assertions
 		self.assertEqual(target_asset.docstatus, 2)  # Ensure Asset is canceled
 
+
+	# TC_FA_149 - Merge Transfer and Issue Asset Movements with Conditional Cancellation
+	def test_multiple_asset_movement_with_purposetype_transfer_issue_149(self):
+		company = "_Test Company"
+		employees = ["_T-Employee-00001", "_T-Employee-00002"]
+		items = ["Test_item_01", "Test_item_02"]
+		assets = []
+
+		# Ensure prerequisites exist
+		if not frappe.db.exists("Company", company):
+			create_child_company()
+
+		for emp_id in employees:
+			if not frappe.db.exists("Employee", emp_id):
+				frappe.get_doc({
+					"doctype": "Employee",
+					"employee_name": emp_id,
+					"first_name": emp_id,
+					"gender": "Male",
+					"date_of_birth": "1990-01-01",
+					"date_of_joining": "2023-01-01",
+					"status": "Active",
+					"company": company
+				}).insert()
+
+		for item_code, employee_id in zip(items, employees):
+			# Create item if it doesn't exist
+			if not frappe.db.exists("Item", item_code):
+				frappe.get_doc({
+					"doctype": "Item",
+					"item_code": item_code,
+					"item_name": item_code,
+					"gst_hsn_code": "01011010",
+					"is_stock_item": 0,
+					"is_fixed_asset": 1,
+					"auto_create_assets": 1,
+					"asset_category": "Test_Category"
+				}).insert()
+
+			# Create asset
+			asset = frappe.get_doc({
+				"doctype": "Asset",
+				"company": company,
+				"item_code": item_code,
+				"asset_name": item_code,
+				"asset_category": "Test_Category",
+				"location": "Test Location",
+				"is_existing_asset": 1,
+				"custodian": employee_id,
+				"owner": "Company",
+				"available_for_use_date": "2024-04-02",
+				"gross_purchase_amount": 8000,
+				"total_asset": 8000,
+				"asset_quantity": 1,
+				"purchase_date": "2024-04-01"
+			}).insert()
+			asset.submit()
+			assets.append(asset.name)
+
+		frappe.db.commit()
+
+		# Create Issue Type Asset Movement
+		issue_movement = frappe.get_doc({
+			"doctype": "Asset Movement",
+			"company": company,
+			"purpose": "Issue",
+			"assets": [{
+				"asset": asset,
+				"source_location": "Test Location",
+				"to_employee": employee_id,
+				"source_cost_center": "_Test Cost Center - _TC"
+			} for asset, employee_id in zip(assets, employees)]
+		})
+		issue_movement.insert()
+		issue_movement.submit()
+		frappe.db.commit()
+
+		# Cancel the Issue Movement
+		issue_movement.cancel()
+		frappe.db.commit()
+
+		# Create Transfer Type Asset Movement using the same assets
+		transfer_movement = frappe.get_doc({
+			"doctype": "Asset Movement",
+			"company": company,
+			"purpose": "Transfer",
+			"assets": [{
+				"asset": asset,
+				"source_location": "Test Location",
+				"from_employee": employee_id,
+				"target_location": "Field 1"
+			} for asset, employee_id in zip(assets, employees)]
+		})
+		transfer_movement.insert()
+		transfer_movement.submit()
+		frappe.db.commit()
+
+	# TC_FA_150
+	def test_single_asset_movement_with_purposetype_transfer_issue_150(self):
+		company = "_Test Company"
+		employee = "_T-Employee-00001"
+		item = "Test_item_01"
+		
+		# Ensure prerequisites exist
+		if not frappe.db.exists("Company", company):
+			create_child_company()
+
+		if not frappe.db.exists("Employee", employee):
+			frappe.get_doc({
+				"doctype": "Employee",
+				"employee_name": employee,
+				"first_name": employee,
+				"gender": "Male",
+				"date_of_birth": "1990-01-01",
+				"date_of_joining": "2023-01-01",
+				"status": "Active",
+				"company": company
+			}).insert()
+
+		if not frappe.db.exists("Item", item):
+			frappe.get_doc({
+				"doctype": "Item",
+				"item_code": item,
+				"item_name": item,
+				"gst_hsn_code": "01011010",
+				"is_stock_item": 0,
+				"is_fixed_asset": 1,
+				"auto_create_assets": 1,
+				"asset_category": "Test_Category"
+			}).insert()
+
+		# Create a single asset
+		asset = frappe.get_doc({
+			"doctype": "Asset",
+			"company": company,
+			"item_code": item,
+			"asset_name": item,
+			"asset_category": "Test_Category",
+			"location": "Test Location",
+			"is_existing_asset": 1,
+			"custodian": employee,
+			"owner": "Company",
+			"available_for_use_date": "2024-04-02",
+			"gross_purchase_amount": 8000,
+			"total_asset": 8000,
+			"asset_quantity": 1,
+			"purchase_date": "2024-04-01"
+		}).insert()
+		asset.submit()
+
+		frappe.db.commit()
+
+		# Create Issue Type Asset Movement (Single Asset Tagged)
+		issue_movement = frappe.get_doc({
+			"doctype": "Asset Movement",
+			"company": company,
+			"purpose": "Issue",
+			"assets": [{
+				"asset": asset.name,
+				"source_location": "Test Location",
+				"to_employee": employee,
+				"source_cost_center": "_Test Cost Center - _TC"
+			}]
+		})
+		issue_movement.insert()
+		issue_movement.submit()
+		frappe.db.commit()
+
+		# Cancel the Issue Movement
+		issue_movement.cancel()
+		frappe.db.commit()
+
+		# Create Transfer Type Asset Movement (Same Single Asset)
+		transfer_movement = frappe.get_doc({
+			"doctype": "Asset Movement",
+			"company": company,
+			"purpose": "Transfer",
+			"assets": [{
+				"asset": asset.name,
+				"source_location": "Test Location",
+				"from_employee": employee,
+				"target_location": "Field 1"
+			}]
+		})
+		transfer_movement.insert()
+		transfer_movement.submit()
+		frappe.db.commit()
+
+	# TC_FA_151
+	def test_multiple_asset_movement_with_purposetype_transfer_issue_151(self):
+		company = "_Test Company"
+		employee = "_T-Employee-00001"
+		item = "Test_item_01"
+		
+		# Ensure prerequisites exist
+		if not frappe.db.exists("Company", company):
+			create_child_company()
+
+		if not frappe.db.exists("Employee", employee):
+			frappe.get_doc({
+				"doctype": "Employee",
+				"employee_name": employee,
+				"first_name": employee,
+				"gender": "Male",
+				"date_of_birth": "1990-01-01",
+				"date_of_joining": "2023-01-01",
+				"status": "Active",
+				"company": company
+			}).insert()
+
+		if not frappe.db.exists("Item", item):
+			frappe.get_doc({
+				"doctype": "Item",
+				"item_code": item,
+				"item_name": item,
+				"gst_hsn_code": "01011010",
+				"is_stock_item": 0,
+				"is_fixed_asset": 1,
+				"auto_create_assets": 1,
+				"asset_category": "Test_Category"
+			}).insert()
+
+		# Create a single asset
+		asset = frappe.get_doc({
+			"doctype": "Asset",
+			"company": company,
+			"item_code": item,
+			"asset_name": item,
+			"asset_category": "Test_Category",
+			"location": "Test Location",
+			"is_existing_asset": 1,
+			"custodian": employee,
+			"owner": "Company",
+			"available_for_use_date": "2024-04-02",
+			"gross_purchase_amount": 8000,
+			"total_asset": 8000,
+			"asset_quantity": 1,
+			"purchase_date": "2024-04-01"
+		}).insert()
+		asset.submit()
+
+		frappe.db.commit()
+
+		# Create Issue Type Asset Movement (Single Asset Tagged)
+		issue_movement = frappe.get_doc({
+			"doctype": "Asset Movement",
+			"company": company,
+			"purpose": "Issue",
+			"assets": [{
+				"asset": asset.name,
+				"source_location": "Test Location",
+				"to_employee": employee,
+				"source_cost_center": "_Test Cost Center - _TC"
+			}]
+		})
+		issue_movement.insert()
+		issue_movement.submit()
+		frappe.db.commit()
+
+		# Cancel the Issue Movement
+		issue_movement.cancel()
+		frappe.db.commit()
+
+		# Create Transfer Type Asset Movement (Same Single Asset)
+		transfer_movement = frappe.get_doc({
+			"doctype": "Asset Movement",
+			"company": company,
+			"purpose": "Transfer",
+			"assets": [{
+				"asset": asset.name,
+				"source_location": "Test Location",
+				"from_employee": employee,
+				"target_location": "Field 1"
+			}]
+		})
+		transfer_movement.insert()
+		transfer_movement.submit()
+		frappe.db.commit()
+
+		# Cancel the Issue Movement
+		transfer_movement.cancel()
+		frappe.db.commit()
+
+	# TC_FA_152
+	def test_single_asset_movement_with_purposetype_transfer_issue_152(self):
+		company = "_Test Company"
+		employee = "_T-Employee-00001"
+		item = "Test_item_01"
+
+		# Ensure prerequisites exist
+		if not frappe.db.exists("Company", company):
+			create_child_company()
+
+		if not frappe.db.exists("Employee", employee):
+			frappe.get_doc({
+				"doctype": "Employee",
+				"employee_name": employee,
+				"first_name": employee,
+				"gender": "Male",
+				"date_of_birth": "1990-01-01",
+				"date_of_joining": "2023-01-01",
+				"status": "Active",
+				"company": company
+			}).insert()
+
+		if not frappe.db.exists("Item", item):
+			frappe.get_doc({
+				"doctype": "Item",
+				"item_code": item,
+				"item_name": item,
+				"gst_hsn_code": "01011010",
+				"is_stock_item": 0,
+				"is_fixed_asset": 1,
+				"auto_create_assets": 1,
+				"asset_category": "Test_Category"
+			}).insert()
+
+		# Create a single asset
+		asset = frappe.get_doc({
+			"doctype": "Asset",
+			"company": company,
+			"item_code": item,
+			"asset_name": item,
+			"asset_category": "Test_Category",
+			"location": "Test Location",
+			"is_existing_asset": 1,
+			"custodian": employee,
+			"owner": "Company",
+			"available_for_use_date": "2024-04-02",
+			"gross_purchase_amount": 8000,
+			"total_asset": 8000,
+			"asset_quantity": 1,
+			"purchase_date": "2024-04-01"
+		}).insert()
+		asset.submit()
+		frappe.db.commit()
+
+		# Create a single asset movement (either Issue or Transfer)
+		asset_movement = frappe.get_doc({
+			"doctype": "Asset Movement",
+			"company": company,
+			"purpose": "Transfer",  # Keeping Transfer, since Issue is being canceled
+			"assets": [{
+				"asset": asset.name,
+				"source_location": "Test Location",
+				"from_employee": employee,
+				"target_location": "Field 1"
+			}]
+		})
+		asset_movement.insert()
+		asset_movement.submit()
+		frappe.db.commit()
+
+		# Cancel the movement
+		asset_movement.cancel()
+		frappe.db.commit()
+
+
+
+
 	# TC_FA_030
 	def test_asset_movement_issue_type_TC_FA_030(self):
 		company = "_Test Company"
@@ -2548,7 +2908,7 @@ class TestAssetMovement(unittest.TestCase):
 				"purpose": "Issue",
 				"assets": [{
 					"asset": target_asset.name,
-					"source_location": "Test Location",
+					"source_location": "Field 1",
 					"to_employee": employe_doc.name,  # Use the name (primary key) of the Employee document
 					"source_cost_center": "_Test Cost Center - _TC"
 				}]


### PR DESCRIPTION
TC_FA_135 , test_create_pi_and_debit_note_TC_FA_135
"1) The asset is auto created on submission of PI in the draft stage. Asset : ACC-ASS-2025-00065 auto created.
2) The status of the PI is updated to Return and debit note is issued.
3) We should not be able to submit the asset since the asset has been returned to the supplier and no longer exists with us."

TC_FA_136 , test_create_pi_asset_and_createdebitnote__TC_FA_136
"1) The asset is auto created on submission of PI in the draft stage. Asset auto created. Submit the asset after entering the available for use date.
2) Create a return/debit note.
3) The system will not allow us to create a debit note/return since the asset has already been submitted. You will need to cancel the asset first and then create a purchase return."

 TC_FA_149, test_multiple_asset_movement_with_purposetype_transfer_issue_149
 When cancelled, the status will change to "Cancelled," and the previous asset movement will be applied to the asset.
 
 TC_FA_150 , test_single_asset_movement_with_purposetype_transfer_issue_150
 When cancelled, the status will change to "Cancelled," and the previous asset movement will be applied to the asset.
 
TC_FA_151 ,  test_multiple_asset_movement_with_purposetype_transfer_issue_151
"When cancelling an Asset Movement Issue, it will update to reflect the previous movement, which was a transfer.  
When cancelling an Asset Movement Transfer, it will update to reflect the previous movement, which was a receipt."

TC_FA_152 , test_single_asset_movement_with_purposetype_transfer_issue_152
"When cancelling an Asset Movement Issue, it will update to reflect the previous movement, which was a transfer.  
When cancelling an Asset Movement Transfer, it will update to reflect the previous movement, which was a receipt."

