### PR TITLE
test:Failed-test-case-scenarios-on-asset-module

### DIFF
--- a/assets/assets/doctype/asset/test_asset.py
+++ b/assets/assets/doctype/asset/test_asset.py
@@ -1273,6 +1273,8 @@ class TestAsset(AssetSetup):
 			# Check if 'gst_hsn_code' exists in Item doctype
 			if frappe.db.has_column("Item", "gst_hsn_code"):
 				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
+			
+			frappe.get_doc(item_data).insert()
 
 		target_asset = frappe.get_doc({
 		"doctype": "Asset",
@@ -1322,12 +1324,11 @@ class TestAsset(AssetSetup):
 
 		# Step 1: Create the Item if it doesn't exist
 		if not frappe.db.exists("Item", item):
-			fa_item = frappe.get_doc({
+			item_data = {
 				"doctype": "Item",
 				"item_code": item,
 				"item_name": item,
 				"item_group": "Products",
-				"gst_hsn_code": "01011010",
 				"stock_uom": "Nos",
 				"is_fixed_asset": 1,
 				"auto_create_assets": 1,
@@ -1335,9 +1336,12 @@ class TestAsset(AssetSetup):
 				"asset_naming_series": "ACC-ASS-.YYYY.-",  # Add the missing naming series
 				"asset_category": "Test_Category"  # Link to Asset Category
 				
-			})
-			fa_item.insert()
-			frappe.db.commit()
+			}
+			# Check if 'gst_hsn_code' exists in Item doctype
+			if frappe.db.has_column("Item", "gst_hsn_code"):
+				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
+			
+			frappe.get_doc(item_data).insert()
 
 		# Step 2: Create and Submit the Purchase Invoice
 		pi = frappe.get_doc({
@@ -1420,7 +1424,7 @@ class TestAsset(AssetSetup):
 				"is_fixed_asset": 1,
 				"auto_create_assets": 1,
 				"is_stock_item": 0,  # Non-stock item
-				"naming_series": "ACC-ASS-.YYYY.-",
+				"asset_naming_series": "ACC-ASS-.YYYY.-",
 				"asset_category": "Test_Category"  # Link to Asset Category
 			})
 			fa_item.insert()
@@ -1490,24 +1494,27 @@ class TestAsset(AssetSetup):
 	# TC_FA_069
 	def test_pi_cancelation_on_asset_depr_scgedule_TC_FA_069(self):
 		supplier = "_Test Supplier"
-		item = "Test_item_cancel_pi"
+		item = "Test_item_cancel_purchasinvoice"
 
 		# Step 1: Create the Item if it doesn't exist
 		if not frappe.db.exists("Item", item):
-			fa_item = frappe.get_doc({
+			item_data = {
 				"doctype": "Item",
 				"item_code": item,
 				"item_name": item,
 				"item_group": "Products",
 				"stock_uom": "Nos",
 				"is_fixed_asset": 1,
-				"gst_hsn_code": "01011010",
 				"auto_create_assets": 1,
 				"is_stock_item": 0,  # Non-stock item
+				"asset_naming_series": "ACC-ASS-.YYYY.-",
 				"asset_category": "Test_Category"  # Link to Asset Category
-			})
-			fa_item.insert()
-			frappe.db.commit()
+			}
+			# Check if 'gst_hsn_code' exists in Item doctype
+			if frappe.db.has_column("Item", "gst_hsn_code"):
+				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
+			
+			frappe.get_doc(item_data).insert()
 
 		# Step 2: Create and Submit the Purchase Invoice
 		pi = frappe.get_doc({

--- a/assets/assets/doctype/asset_maintenance/test_asset_maintenance.py
+++ b/assets/assets/doctype/asset_maintenance/test_asset_maintenance.py
@@ -31,7 +31,7 @@ class TestAssetMaintenance(unittest.TestCase):
 
 		# Create the item if it doesn't exist
 		if not frappe.db.exists("Item", item_code):
-			frappe.get_doc({
+			item_data = {
 				"doctype": "Item",
 				"item_code": item_code,
 				"item_name": item_code,
@@ -39,7 +39,11 @@ class TestAssetMaintenance(unittest.TestCase):
 				"is_fixed_asset": 1,
 				"auto_create_assets": 1,
 				"asset_category": "Test_Category"
-			}).insert()
+			}
+
+			# Check if 'gst_hsn_code' exists in Item doctype
+			if frappe.db.has_column("Item", "gst_hsn_code"):
+				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
 
 		
 		target_asset = frappe.get_doc({
@@ -107,7 +111,7 @@ class TestAssetMaintenance(unittest.TestCase):
 
 		# Create the item if it doesn't exist
 		if not frappe.db.exists("Item", item_code):
-			frappe.get_doc({
+			item_data = {
 				"doctype": "Item",
 				"item_code": item_code,
 				"item_name": item_code,
@@ -115,7 +119,11 @@ class TestAssetMaintenance(unittest.TestCase):
 				"is_fixed_asset": 1,
 				"auto_create_assets": 1,
 				"asset_category": "Test_Category"
-			}).insert()
+			}
+
+			# Check if 'gst_hsn_code' exists in Item doctype
+			if frappe.db.has_column("Item", "gst_hsn_code"):
+				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
 
 		
 		target_asset = frappe.get_doc({
@@ -183,7 +191,7 @@ class TestAssetMaintenance(unittest.TestCase):
 
 		# Create the item if it doesn't exist
 		if not frappe.db.exists("Item", item_code):
-			frappe.get_doc({
+			item_data = {
 				"doctype": "Item",
 				"item_code": item_code,
 				"item_name": item_code,
@@ -191,7 +199,11 @@ class TestAssetMaintenance(unittest.TestCase):
 				"is_fixed_asset": 1,
 				"auto_create_assets": 1,
 				"asset_category": "Test_Category"
-			}).insert()
+			}
+
+			# Check if 'gst_hsn_code' exists in Item doctype
+			if frappe.db.has_column("Item", "gst_hsn_code"):
+				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
 
 		
 		target_asset = frappe.get_doc({
@@ -259,7 +271,7 @@ class TestAssetMaintenance(unittest.TestCase):
 
 		# Create the item if it doesn't exist
 		if not frappe.db.exists("Item", item_code):
-			frappe.get_doc({
+			item_data = {
 				"doctype": "Item",
 				"item_code": item_code,
 				"item_name": item_code,
@@ -267,7 +279,11 @@ class TestAssetMaintenance(unittest.TestCase):
 				"is_fixed_asset": 1,
 				"auto_create_assets": 1,
 				"asset_category": "Test_Category"
-			}).insert()
+			}
+
+			# Check if 'gst_hsn_code' exists in Item doctype
+			if frappe.db.has_column("Item", "gst_hsn_code"):
+				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
 
 		
 		target_asset = frappe.get_doc({
@@ -335,7 +351,7 @@ class TestAssetMaintenance(unittest.TestCase):
 
 		# Create the item if it doesn't exist
 		if not frappe.db.exists("Item", item_code):
-			frappe.get_doc({
+			item_data = {
 				"doctype": "Item",
 				"item_code": item_code,
 				"item_name": item_code,
@@ -343,7 +359,11 @@ class TestAssetMaintenance(unittest.TestCase):
 				"is_fixed_asset": 1,
 				"auto_create_assets": 1,
 				"asset_category": "Test_Category"
-			}).insert()
+			}
+
+			# Check if 'gst_hsn_code' exists in Item doctype
+			if frappe.db.has_column("Item", "gst_hsn_code"):
+				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
 
 		
 		target_asset = frappe.get_doc({
@@ -411,7 +431,7 @@ class TestAssetMaintenance(unittest.TestCase):
 
 		# Create the item if it doesn't exist
 		if not frappe.db.exists("Item", item_code):
-			frappe.get_doc({
+			item_data = {
 				"doctype": "Item",
 				"item_code": item_code,
 				"item_name": item_code,
@@ -419,7 +439,11 @@ class TestAssetMaintenance(unittest.TestCase):
 				"is_fixed_asset": 1,
 				"auto_create_assets": 1,
 				"asset_category": "Test_Category"
-			}).insert()
+			}
+			# Check if 'gst_hsn_code' exists in Item doctype
+			if frappe.db.has_column("Item", "gst_hsn_code"):
+				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
+
 
 		
 		target_asset = frappe.get_doc({

--- a/assets/assets/doctype/asset_movement/test_asset_movement.py
+++ b/assets/assets/doctype/asset_movement/test_asset_movement.py
@@ -245,17 +245,37 @@ class TestAssetMovement(unittest.TestCase):
 		if not frappe.db.exists("Company", company):
 			create_child_company()
 		if not frappe.db.exists("Item", item_code):
-			frappe.get_doc({
+			item_data = {
 				"doctype": "Item",
 				"item_code": item_code,
 				"item_name": item_code,
 				"is_stock_item": 0,
 				"is_fixed_asset": 1,
-				"gst_hsn_code":"01011010",
 				"asset_naming_series": "ACC-ASS-.YYYY.-",
 				"auto_create_assets": 1,
 				"asset_category": "Test_Category"
-			}).insert()
+			}
+
+			# Check if 'gst_hsn_code' exists in Item doctype
+			if frappe.db.has_column("Item", "gst_hsn_code"):
+				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
+			
+			frappe.get_doc(item_data).insert()
+
+		if not frappe.db.exists("Employee", "Test_employee_issue"):
+			employee_doc = frappe.get_doc({
+					"doctype": "Employee",
+					"employee_name": "Test_employee_issue",
+					"first_name": "Test_employee_issue",
+					"gender": "Male",
+					"date_of_birth": "1990-01-01",
+					"date_of_joining": "2023-01-01",
+					"status": "Active",
+					"company": company
+				}).insert()
+		else:
+			# Fetch existing employee document
+			employee_doc = frappe.get_doc("Employee", "Test_employee_issue")
 
 		target_asset = frappe.get_doc({
 			"doctype": "Asset",
@@ -266,6 +286,7 @@ class TestAssetMovement(unittest.TestCase):
 			"location": "Test Location",
 			"is_existing_asset":1,
 			"asset_owner":"Company",
+			"custodian" : employee_doc.name,
 			"available_for_use_date":"02-04-2024",
 			"gross_purchase_amount":8000,
 			"total_asset":8000,
@@ -284,17 +305,7 @@ class TestAssetMovement(unittest.TestCase):
 		target_asset.submit()
 		frappe.db.commit()
 
-		if not frappe.db.exists("Employee", "Test_employee_issue"):
-			employee_doc = frappe.get_doc({
-					"doctype": "Employee",
-					"employee_name": "Test_employee_issue",
-					"first_name": "Test_employee_issue",
-					"gender": "Male",
-					"date_of_birth": "1990-01-01",
-					"date_of_joining": "2023-01-01",
-					"status": "Active",
-					"company": company
-				}).insert()
+		
 
 		if target_asset:
 			asset_movement = frappe.get_doc({

--- a/assets/assets/doctype/asset_repair/test_asset_repair.py
+++ b/assets/assets/doctype/asset_repair/test_asset_repair.py
@@ -45,15 +45,21 @@ class TestAssetRepair(unittest.TestCase):
 
 		# Create the item if it doesn't exist
 		if not frappe.db.exists("Item", item_code):
-			frappe.get_doc({
+			item_data = {
 				"doctype": "Item",
 				"item_code": item_code,
 				"item_name": item_code,
+				"is_stock_item":0,
+				"is_fixed_asset":1,
 				"gst_hsn_code":"888890",
 				"item_group":"Raw Material",
 				"stock_uom":"Nos",
-
-			}).insert()
+				"asset_naming_series": "ACC-ASS-.YYYY.-",
+				"asset_category": "Test_Category"
+			}
+			# Check if 'gst_hsn_code' exists in Item doctype
+			if frappe.db.has_column("Item", "gst_hsn_code"):
+				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
 
 		
 		target_asset = frappe.get_doc({


### PR DESCRIPTION
Getting the gst_hsn code error because the gst_hsn code was not handled

Fix:
Checking  the gst_hsn code field before inserting it on dabase wheter the field is present or not

# Check if 'gst_hsn_code' exists in Item doctype
			if frappe.db.has_column("Item", "gst_hsn_code"):
				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists

			frappe.get_doc(item_data).insert()