### PR TITLE
test: add test for add multiple assets item with single and check assets creating while creation of purchase invoice with gst(TC_FA_102,TC_FA_103,TC_FA_104 and TC_FA_105)

### DIFF
--- a/assets/assets/doctype/asset/test_asset.py
+++ b/assets/assets/doctype/asset/test_asset.py
@@ -6,7 +6,7 @@ import unittest
 import frappe
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
 from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import (
-	make_purchase_invoice,
+	make_purchase_invoice,check_gl_entries
 )
 from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
 	make_purchase_invoice as make_invoice,
@@ -5160,228 +5160,360 @@ class TestDepreciationBasics(AssetSetup):
 
 	
 	def test_multiple_asset_purchasing_single_invoice_TC_FA_102(self):
-		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
-			make_test_item,
-			create_records,
-			create_company
-		)
-		create_records('_Test Supplier')
-		create_company()
-		if not frappe.db.exists("Location", "Test Location"):
-			frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
-	
-		item_list =["_Test Item Asset 1", "_Test Item Asset 2"]
+		from frappe.tests.utils import if_app_installed
 		
+		if if_app_installed("erpnext"): 
+			from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+				make_test_item,
+				create_records,
+				create_company
+			)
+			create_records('_Test Supplier')
+			create_company()
+			if not frappe.db.exists("Location", "Test Location"):
+				frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
+		
+			item_list =["_Test Item Asset 1", "_Test Item Asset 2"]
 			
-		for item in item_list:
-			if not frappe.db.exists("Item", item):
-				item = make_test_item(item)
-				item.is_stock_item = 0
-				item.is_fixed_asset = 1
-				item.asset_naming_series="ACC-ASS-.YYYY.-"
-				item.asset_category = "Computers"
-				item.is_grouped_asset = 1
-				item.auto_create_assets = 1
-				item.save()
-		
-		pi = make_purchase_invoice(
-			supplier="_Test Supplier",
-			company="_Test Company",
-			item_code="_Test Item Asset 1",
-			qty=1,
-			rate=100.0,
-			location="Test Location",
-			do_not_submit=True,
-			update_stock=True
-   		)
-		pi.append("items",{
-			"item_code":"_Test Item Asset 2",
-			"qty":1,
-			"uom":"Nos",
-			"rate":1000,
-			"asset_location":"Test Location"
-		})
-		pi.save()
-		pi.submit()
-	    
-		assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
-		
-		for asset in assets_name:
-			asset_doc = frappe.get_doc("Asset",asset.name)
-			self.assertEqual(pi.name,asset_doc.purchase_invoice)
+				
+			for item in item_list:
+				if not frappe.db.exists("Item", item):
+					item = make_test_item(item)
+					item.is_stock_item = 0
+					item.is_fixed_asset = 1
+					item.asset_naming_series="ACC-ASS-.YYYY.-"
+					item.asset_category = "Computers"
+					item.is_grouped_asset = 1
+					item.auto_create_assets = 1
+					item.save()
+			
+			pi = make_purchase_invoice(
+				supplier="_Test Supplier",
+				company="_Test Company",
+				item_code="_Test Item Asset 1",
+				qty=1,
+				rate=100.0,
+				location="Test Location",
+				do_not_submit=True,
+				update_stock=True
+			)
+			pi.append("items",{
+				"item_code":"_Test Item Asset 2",
+				"qty":1,
+				"uom":"Nos",
+				"rate":1000,
+				"asset_location":"Test Location"
+			})
+			pi.save()
+			pi.submit()
+			
+			assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
+			
+			for asset in assets_name:
+				asset_doc = frappe.get_doc("Asset",asset.name)
+				self.assertEqual(pi.name,asset_doc.purchase_invoice)
    
 	def test_multiple_asset_purchasing_single_invoice_with_gst_TC_FA_103(self):
-		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
-			make_test_item,
-			create_records,
-			create_company
-		)
-		create_records('_Test Supplier')
-		create_company()
-		if frappe.db.exists("Purchase Taxes and Charges Template", "Input GST Out-state - _TC"):
-			doc = frappe.get_doc("Purchase Taxes and Charges Template", "Input GST Out-state - _TC")
-			doc.taxes[0].rate = 12
-			doc.save()
-		if not frappe.db.exists("Location", "Test Location"):
-			frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
-	
-		item_list =["_Test Item Asset 1", "_Test Item Asset 2"]
+		from frappe.tests.utils import if_app_installed
 		
+		if if_app_installed("erpnext"): 
+			from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+				make_test_item,
+				create_records,
+				create_company
+			)
+			create_records('_Test Supplier')
+			create_company()
+			if frappe.db.exists("Purchase Taxes and Charges Template", "Input GST Out-state - _TC"):
+				doc = frappe.get_doc("Purchase Taxes and Charges Template", "Input GST Out-state - _TC")
+				doc.taxes[0].rate = 12
+				doc.save()
+			if not frappe.db.exists("Location", "Test Location"):
+				frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
+		
+			item_list =["_Test Item Asset 1", "_Test Item Asset 2"]
 			
-		for item in item_list:
-			if not frappe.db.exists("Item", item):
-				item = make_test_item(item)
-				item.is_stock_item = 0
-				item.is_fixed_asset = 1
-				item.asset_naming_series="ACC-ASS-.YYYY.-"
-				item.asset_category = "Computers"
-				item.is_grouped_asset = 1
-				item.auto_create_assets = 1
-				item.save()
+				
+			for item in item_list:
+				if not frappe.db.exists("Item", item):
+					item = make_test_item(item)
+					item.is_stock_item = 0
+					item.is_fixed_asset = 1
+					item.asset_naming_series="ACC-ASS-.YYYY.-"
+					item.asset_category = "Computers"
+					item.is_grouped_asset = 1
+					item.auto_create_assets = 1
+					item.save()
+			
+			pi = make_purchase_invoice(
+				supplier="_Test Supplier",
+				company="_Test Company",
+				item_code="_Test Item Asset 1",
+				qty=1,
+				rate=1000.0,
+				location="Test Location",
+				do_not_submit=True,
+				update_stock=True
+			)
+			pi.append("items",{
+				"item_code":"_Test Item Asset 2",
+				"qty":1,
+				"uom":"Nos",
+				"rate":1000,
+				"asset_location":"Test Location"
+			})
+			pi.taxes_and_charges = "Input GST Out-state - _TC"
+			pi.save()
+			pi.submit()
 		
-		pi = make_purchase_invoice(
-			supplier="_Test Supplier",
-			company="_Test Company",
-			item_code="_Test Item Asset 1",
-			qty=1,
-			rate=1000.0,
-			location="Test Location",
-			do_not_submit=True,
-			update_stock=True
-   		)
-		pi.append("items",{
-			"item_code":"_Test Item Asset 2",
-			"qty":1,
-			"uom":"Nos",
-			"rate":1000,
-			"asset_location":"Test Location"
-		})
-		pi.taxes_and_charges = "Input GST Out-state - _TC"
-		pi.save()
-		pi.submit()
-	
-		self.assertTrue(get_gl_entries(pi.doctype, pi.name))
-		
-		assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
-		gross_purchase_amount =0.0 
-		for asset in assets_name:
-			asset_doc = frappe.get_doc("Asset",asset.name)
-			self.assertEqual(pi.name,asset_doc.purchase_invoice)
-			gross_purchase_amount += asset_doc.gross_purchase_amount
-		
-		self.assertEqual(gross_purchase_amount,pi.total)
+			self.assertTrue(get_gl_entries(pi.doctype, pi.name))
+			
+			assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
+			gross_purchase_amount =0.0 
+			for asset in assets_name:
+				asset_doc = frappe.get_doc("Asset",asset.name)
+				self.assertEqual(pi.name,asset_doc.purchase_invoice)
+				gross_purchase_amount += asset_doc.gross_purchase_amount
+			
+			self.assertEqual(gross_purchase_amount,pi.total)
 	
 	def test_multiple_group_asset_purchasing_single_invoice_104(self):
-		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
-			make_test_item,
-			create_records,
-			create_company
-		)
-		create_records('_Test Supplier')
-		create_company()
-		if not frappe.db.exists("Location", "Test Location"):
-			frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
+		from frappe.tests.utils import if_app_installed
 		
-		item_list =["_Test Item Group Asset 1", "_Test Item Group Asset 2"]
-		
-		for item in item_list:
-			if not frappe.db.exists("Item", item):
-				item = make_test_item(item)
-				item.is_stock_item = 0
-				item.is_fixed_asset = 1
-				item.asset_naming_series="ACC-ASS-.YYYY.-"
-				item.asset_category = "Computers"
-				item.is_grouped_asset = 1
-				item.auto_create_assets = 1
-				item.save()
+		if if_app_installed("erpnext"): 
+			from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+				make_test_item,
+				create_records,
+				create_company
+			)
+			create_records('_Test Supplier')
+			create_company()
+			if not frappe.db.exists("Location", "Test Location"):
+				frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
 			
-		pi = make_purchase_invoice(
-			supplier="_Test Supplier",
-			company="_Test Company",
-			item_code="_Test Item Group Asset 1",
-			qty=10,
-			rate=1000.0,
-			location="Test Location",
-			do_not_submit=True,
-			update_stock=True
-   		)
-		pi.append("items",{
-			"item_code":"_Test Item Group Asset 2",
-			"qty":10,
-			"uom":"Nos",
-			"rate":1000,
-			"asset_location":"Test Location"
-		})
-		pi.save()
-		pi.submit()
-	    
-		assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
-		self.assertEqual(len(assets_name),2)
-		for asset in assets_name:
-			asset_doc = frappe.get_doc("Asset",asset.name)
-			self.assertEqual(pi.name,asset_doc.purchase_invoice)
+			item_list =["_Test Item Group Asset 1", "_Test Item Group Asset 2"]
+			
+			for item in item_list:
+				if not frappe.db.exists("Item", item):
+					item = make_test_item(item)
+					item.is_stock_item = 0
+					item.is_fixed_asset = 1
+					item.asset_naming_series="ACC-ASS-.YYYY.-"
+					item.asset_category = "Computers"
+					item.is_grouped_asset = 1
+					item.auto_create_assets = 1
+					item.save()
+				
+			pi = make_purchase_invoice(
+				supplier="_Test Supplier",
+				company="_Test Company",
+				item_code="_Test Item Group Asset 1",
+				qty=10,
+				rate=1000.0,
+				location="Test Location",
+				do_not_submit=True,
+				update_stock=True
+			)
+			pi.append("items",{
+				"item_code":"_Test Item Group Asset 2",
+				"qty":10,
+				"uom":"Nos",
+				"rate":1000,
+				"asset_location":"Test Location"
+			})
+			pi.save()
+			pi.submit()
+			
+			assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
+			self.assertEqual(len(assets_name),2)
+			for asset in assets_name:
+				asset_doc = frappe.get_doc("Asset",asset.name)
+				self.assertEqual(pi.name,asset_doc.purchase_invoice)
    
    
 	def test_multiple_group_asset_purchasing_single_invoice_with_gst_105(self):
-		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
-			make_test_item,
-			create_records,
-			create_company
-		)
-		create_records('_Test Supplier')
-		create_company()
-		if frappe.db.exists("Purchase Taxes and Charges Template", "Input GST Out-state - _TC"):
-			doc = frappe.get_doc("Purchase Taxes and Charges Template", "Input GST Out-state - _TC")
-			doc.taxes[0].rate = 12
-			doc.save()
-		if not frappe.db.exists("Location", "Test Location"):
-			frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
+		from frappe.tests.utils import if_app_installed
 		
-		item_list =["_Test Item Group Asset 1", "_Test Item Group Asset 2"]
-		
-		for item in item_list:
-			if not frappe.db.exists("Item", item):
-				item = make_test_item(item)
-				item.is_stock_item = 0
-				item.is_fixed_asset = 1
-				item.asset_naming_series="ACC-ASS-.YYYY.-"
-				item.asset_category = "Computers"
-				item.is_grouped_asset = 1
-				item.auto_create_assets = 1
-				item.save()
+		if if_app_installed("erpnext"): 
+			from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+				make_test_item,
+				create_records,
+				create_company
+			)
+			create_records('_Test Supplier')
+			create_company()
+			if frappe.db.exists("Purchase Taxes and Charges Template", "Input GST Out-state - _TC"):
+				doc = frappe.get_doc("Purchase Taxes and Charges Template", "Input GST Out-state - _TC")
+				doc.taxes[0].rate = 12
+				doc.save()
+			if not frappe.db.exists("Location", "Test Location"):
+				frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
 			
-		pi = make_purchase_invoice(
-			supplier="_Test Supplier",
-			company="_Test Company",
-			item_code="_Test Item Group Asset 1",
-			qty=10,
-			rate=1000.0,
-			location="Test Location",
-			do_not_submit=True,
-			update_stock=True
-   		)
-		pi.append("items",{
-			"item_code":"_Test Item Group Asset 2",
-			"qty":10,
-			"uom":"Nos",
-			"rate":1000,
-			"asset_location":"Test Location"
-		})
-		pi.taxes_and_charges = "Input GST Out-state - _TC"
-		pi.save()
-		pi.submit()
-	
-		self.assertTrue(get_gl_entries(pi.doctype, pi.name))
-	    
-		assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
-		self.assertEqual(len(assets_name),2)
-		gross_purchase_amount =0.0 
-		for asset in assets_name:
-			asset_doc = frappe.get_doc("Asset",asset.name)
-			self.assertEqual(pi.name,asset_doc.purchase_invoice)
-			gross_purchase_amount += asset_doc.gross_purchase_amount
+			item_list =["_Test Item Group Asset 1", "_Test Item Group Asset 2"]
+			
+			for item in item_list:
+				if not frappe.db.exists("Item", item):
+					item = make_test_item(item)
+					item.is_stock_item = 0
+					item.is_fixed_asset = 1
+					item.asset_naming_series="ACC-ASS-.YYYY.-"
+					item.asset_category = "Computers"
+					item.is_grouped_asset = 1
+					item.auto_create_assets = 1
+					item.save()
+				
+			pi = make_purchase_invoice(
+				supplier="_Test Supplier",
+				company="_Test Company",
+				item_code="_Test Item Group Asset 1",
+				qty=10,
+				rate=1000.0,
+				location="Test Location",
+				do_not_submit=True,
+				update_stock=True
+			)
+			pi.append("items",{
+				"item_code":"_Test Item Group Asset 2",
+				"qty":10,
+				"uom":"Nos",
+				"rate":1000,
+				"asset_location":"Test Location"
+			})
+			pi.taxes_and_charges = "Input GST Out-state - _TC"
+			pi.save()
+			pi.submit()
 		
-		self.assertEqual(gross_purchase_amount,pi.total)
+			self.assertTrue(get_gl_entries(pi.doctype, pi.name))
+			
+			assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
+			self.assertEqual(len(assets_name),2)
+			gross_purchase_amount =0.0 
+			for asset in assets_name:
+				asset_doc = frappe.get_doc("Asset",asset.name)
+				self.assertEqual(pi.name,asset_doc.purchase_invoice)
+				gross_purchase_amount += asset_doc.gross_purchase_amount
+			
+			self.assertEqual(gross_purchase_amount,pi.total)
+  
+	def test_create_subsidy_jv_for_fixed_assets_TC_FA_091(self):
+		from frappe.tests.utils import if_app_installed
+		
+		if if_app_installed("erpnext"): 
+			from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+				make_test_item,
+				create_records,
+				create_company,
+			)
+			from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
+			create_records('_Test Supplier')
+			create_company()
+			if not frappe.db.exists("Location", "Test Location"):
+				frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
+			
+			item_list =["_Test Item Group Asset 1", "_Test Item Group Asset 2"]
+			
+			for item in item_list:
+				if not frappe.db.exists("Item", item):
+					item = make_test_item(item)
+					item.is_stock_item = 0
+					item.is_fixed_asset = 1
+					item.asset_naming_series="ACC-ASS-.YYYY.-"
+					item.asset_category = "Computers"
+					item.is_grouped_asset = 1
+					item.auto_create_assets = 1
+					item.save()
+				
+			pi = make_purchase_invoice(
+				supplier="_Test Supplier",
+				company="_Test Company",
+				item_code="_Test Item Group Asset 1",
+				qty=10,
+				rate=100000.0,
+				location="Test Location",
+				do_not_submit=True,
+				update_stock=True
+			)
+			pi.save()
+			pi.submit()
+			
+			assets_name = frappe.get_value("Asset",{"purchase_invoice":pi.name},"name")
+			
+			jv = make_journal_entry(
+				account1="_Test Bank - _TC",
+				account2="_Test Subsidy - _TC",
+				amount=100000.0,
+				posting_date=pi.posting_date,
+				save=False
+			)
+			jv.accounts[1].reference_type = "Asset"
+			jv.accounts[1].reference_name = assets_name
+			jv.save()
+			jv.submit()
+			expected_gle = [
+				['_Test Bank - _TC', 100000.0, 0.0, jv.posting_date],
+				['_Test Subsidy - _TC', 0.0, 100000.0, jv.posting_date]
+			]
+			check_gl_entries(self,voucher_no=jv.name,expected_gle=expected_gle,posting_date=jv.posting_date,voucher_type=jv.doctype)
+	def test_create_subsidy_jv_for_fixed_assets_partial_ammount_TC_FA_092(self):
+		from frappe.tests.utils import if_app_installed
+		
+		if if_app_installed("erpnext"): 
+			from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+				make_test_item,
+				create_records,
+				create_company,
+			)
+			from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
+			create_records('_Test Supplier')
+			create_company()
+			if not frappe.db.exists("Location", "Test Location"):
+				frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
+			
+			item_list =["_Test Item Group Asset 1", "_Test Item Group Asset 2"]
+			
+			for item in item_list:
+				if not frappe.db.exists("Item", item):
+					item = make_test_item(item)
+					item.is_stock_item = 0
+					item.is_fixed_asset = 1
+					item.asset_naming_series="ACC-ASS-.YYYY.-"
+					item.asset_category = "Computers"
+					item.is_grouped_asset = 1
+					item.auto_create_assets = 1
+					item.save()
+				
+			pi = make_purchase_invoice(
+				supplier="_Test Supplier",
+				company="_Test Company",
+				item_code="_Test Item Group Asset 1",
+				qty=10,
+				rate=100000.0,
+				location="Test Location",
+				do_not_submit=True,
+				update_stock=True
+			)
+			pi.save()
+			pi.submit()
+			
+			assets_name = frappe.get_value("Asset",{"purchase_invoice":pi.name},"name")
+			
+			jv = make_journal_entry(
+				account1="_Test Bank - _TC",
+				account2="_Test Subsidy - _TC",
+				amount=100000.0,
+				posting_date=pi.posting_date,
+				save=False
+			)
+			jv.accounts[1].reference_type = "Asset"
+			jv.accounts[1].reference_name = assets_name
+			jv.save()
+			jv.submit()
+			expected_gle = [
+				['_Test Bank - _TC', 100000.0, 0.0, jv.posting_date],
+				['_Test Subsidy - _TC', 0.0, 100000.0, jv.posting_date]
+			]
+			check_gl_entries(self,voucher_no=jv.name,expected_gle=expected_gle,posting_date=jv.posting_date,voucher_type=jv.doctype)
+			
 def get_gl_entries(doctype, docname):
 	gl_entry = frappe.qb.DocType("GL Entry")
 	return (

--- a/assets/assets/doctype/asset/test_asset.py
+++ b/assets/assets/doctype/asset/test_asset.py
@@ -18,6 +18,7 @@ from erpnext.stock.doctype.material_request.material_request import make_purchas
 from erpnext.setup.doctype.company.test_company import create_child_company
 from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
 from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+from frappe.tests.utils import if_app_installed
 from frappe.utils import (
 	add_days,
 	add_months,
@@ -5158,485 +5159,468 @@ class TestDepreciationBasics(AssetSetup):
 		pr.submit()
 		self.assertTrue(get_gl_entries("Purchase Receipt", pr.name))
 
-	
+	@if_app_installed("erpnext")
 	def test_multiple_asset_purchasing_single_invoice_TC_FA_102(self):
-		from frappe.tests.utils import if_app_installed
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+			make_test_item,
+			create_records,
+			create_company
+		)
+		create_records('_Test Supplier')
+		create_company()
+		if not frappe.db.exists("Location", "Test Location"):
+			frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
+	
+		item_list =["_Test Item Asset 1", "_Test Item Asset 2"]
 		
-		if if_app_installed("erpnext"): 
-			from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
-				make_test_item,
-				create_records,
-				create_company
-			)
-			create_records('_Test Supplier')
-			create_company()
-			if not frappe.db.exists("Location", "Test Location"):
-				frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
+			
+		for item in item_list:
+			if not frappe.db.exists("Item", item):
+				item = make_test_item(item)
+				item.is_stock_item = 0
+				item.is_fixed_asset = 1
+				item.asset_naming_series="ACC-ASS-.YYYY.-"
+				item.asset_category = "Computers"
+				item.is_grouped_asset = 1
+				item.auto_create_assets = 1
+				item.save()
 		
-			item_list =["_Test Item Asset 1", "_Test Item Asset 2"]
-			
-				
-			for item in item_list:
-				if not frappe.db.exists("Item", item):
-					item = make_test_item(item)
-					item.is_stock_item = 0
-					item.is_fixed_asset = 1
-					item.asset_naming_series="ACC-ASS-.YYYY.-"
-					item.asset_category = "Computers"
-					item.is_grouped_asset = 1
-					item.auto_create_assets = 1
-					item.save()
-			
-			pi = make_purchase_invoice(
-				supplier="_Test Supplier",
-				company="_Test Company",
-				item_code="_Test Item Asset 1",
-				qty=1,
-				rate=100.0,
-				location="Test Location",
-				do_not_submit=True,
-				update_stock=True
-			)
-			pi.append("items",{
-				"item_code":"_Test Item Asset 2",
-				"qty":1,
-				"uom":"Nos",
-				"rate":1000,
-				"asset_location":"Test Location"
-			})
-			pi.save()
-			pi.submit()
-			
-			assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
-			
-			for asset in assets_name:
-				asset_doc = frappe.get_doc("Asset",asset.name)
-				self.assertEqual(pi.name,asset_doc.purchase_invoice)
+		pi = make_purchase_invoice(
+			supplier="_Test Supplier",
+			company="_Test Company",
+			item_code="_Test Item Asset 1",
+			qty=1,
+			rate=100.0,
+			location="Test Location",
+			do_not_submit=True,
+			update_stock=True
+		)
+		pi.append("items",{
+			"item_code":"_Test Item Asset 2",
+			"qty":1,
+			"uom":"Nos",
+			"rate":1000,
+			"asset_location":"Test Location"
+		})
+		pi.save()
+		pi.submit()
+		
+		assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
+		
+		for asset in assets_name:
+			asset_doc = frappe.get_doc("Asset",asset.name)
+			self.assertEqual(pi.name,asset_doc.purchase_invoice)
    
+	@if_app_installed("erpnext")
 	def test_multiple_asset_purchasing_single_invoice_with_gst_TC_FA_103(self):
-		from frappe.tests.utils import if_app_installed
-		
-		if if_app_installed("erpnext"): 
-			from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
-				make_test_item,
-				create_records,
-				create_company
-			)
-			create_records('_Test Supplier')
-			create_company()
-			if frappe.db.exists("Purchase Taxes and Charges Template", "Input GST Out-state - _TC"):
-				doc = frappe.get_doc("Purchase Taxes and Charges Template", "Input GST Out-state - _TC")
-				doc.taxes[0].rate = 12
-				doc.save()
-			if not frappe.db.exists("Location", "Test Location"):
-				frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
-		
-			item_list =["_Test Item Asset 1", "_Test Item Asset 2"]
-			
-				
-			for item in item_list:
-				if not frappe.db.exists("Item", item):
-					item = make_test_item(item)
-					item.is_stock_item = 0
-					item.is_fixed_asset = 1
-					item.asset_naming_series="ACC-ASS-.YYYY.-"
-					item.asset_category = "Computers"
-					item.is_grouped_asset = 1
-					item.auto_create_assets = 1
-					item.save()
-			
-			pi = make_purchase_invoice(
-				supplier="_Test Supplier",
-				company="_Test Company",
-				item_code="_Test Item Asset 1",
-				qty=1,
-				rate=1000.0,
-				location="Test Location",
-				do_not_submit=True,
-				update_stock=True
-			)
-			pi.append("items",{
-				"item_code":"_Test Item Asset 2",
-				"qty":1,
-				"uom":"Nos",
-				"rate":1000,
-				"asset_location":"Test Location"
-			})
-			pi.taxes_and_charges = "Input GST Out-state - _TC"
-			pi.save()
-			pi.submit()
-		
-			self.assertTrue(get_gl_entries(pi.doctype, pi.name))
-			
-			assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
-			gross_purchase_amount =0.0 
-			for asset in assets_name:
-				asset_doc = frappe.get_doc("Asset",asset.name)
-				self.assertEqual(pi.name,asset_doc.purchase_invoice)
-				gross_purchase_amount += asset_doc.gross_purchase_amount
-			
-			self.assertEqual(gross_purchase_amount,pi.total)
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+			make_test_item,
+			create_records,
+			create_company
+		)
+		create_records('_Test Supplier')
+		create_company()
+		if frappe.db.exists("Purchase Taxes and Charges Template", "Input GST Out-state - _TC"):
+			doc = frappe.get_doc("Purchase Taxes and Charges Template", "Input GST Out-state - _TC")
+			doc.taxes[0].rate = 12
+			doc.save()
+		if not frappe.db.exists("Location", "Test Location"):
+			frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
 	
-	def test_multiple_group_asset_purchasing_single_invoice_104(self):
-		from frappe.tests.utils import if_app_installed
+		item_list =["_Test Item Asset 1", "_Test Item Asset 2"]
 		
-		if if_app_installed("erpnext"): 
-			from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
-				make_test_item,
-				create_records,
-				create_company
-			)
-			create_records('_Test Supplier')
-			create_company()
-			if not frappe.db.exists("Location", "Test Location"):
-				frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
 			
-			item_list =["_Test Item Group Asset 1", "_Test Item Group Asset 2"]
-			
-			for item in item_list:
-				if not frappe.db.exists("Item", item):
-					item = make_test_item(item)
-					item.is_stock_item = 0
-					item.is_fixed_asset = 1
-					item.asset_naming_series="ACC-ASS-.YYYY.-"
-					item.asset_category = "Computers"
-					item.is_grouped_asset = 1
-					item.auto_create_assets = 1
-					item.save()
-				
-			pi = make_purchase_invoice(
-				supplier="_Test Supplier",
-				company="_Test Company",
-				item_code="_Test Item Group Asset 1",
-				qty=10,
-				rate=1000.0,
-				location="Test Location",
-				do_not_submit=True,
-				update_stock=True
-			)
-			pi.append("items",{
-				"item_code":"_Test Item Group Asset 2",
-				"qty":10,
-				"uom":"Nos",
-				"rate":1000,
-				"asset_location":"Test Location"
-			})
-			pi.save()
-			pi.submit()
-			
-			assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
-			self.assertEqual(len(assets_name),2)
-			for asset in assets_name:
-				asset_doc = frappe.get_doc("Asset",asset.name)
-				self.assertEqual(pi.name,asset_doc.purchase_invoice)
-   
-   
-	def test_multiple_group_asset_purchasing_single_invoice_with_gst_105(self):
-		from frappe.tests.utils import if_app_installed
+		for item in item_list:
+			if not frappe.db.exists("Item", item):
+				item = make_test_item(item)
+				item.is_stock_item = 0
+				item.is_fixed_asset = 1
+				item.asset_naming_series="ACC-ASS-.YYYY.-"
+				item.asset_category = "Computers"
+				item.is_grouped_asset = 1
+				item.auto_create_assets = 1
+				item.save()
 		
-		if if_app_installed("erpnext"): 
-			from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
-				make_test_item,
-				create_records,
-				create_company
-			)
-			create_records('_Test Supplier')
-			create_company()
-			if frappe.db.exists("Purchase Taxes and Charges Template", "Input GST Out-state - _TC"):
-				doc = frappe.get_doc("Purchase Taxes and Charges Template", "Input GST Out-state - _TC")
-				doc.taxes[0].rate = 12
-				doc.save()
-			if not frappe.db.exists("Location", "Test Location"):
-				frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
-			
-			item_list =["_Test Item Group Asset 1", "_Test Item Group Asset 2"]
-			
-			for item in item_list:
-				if not frappe.db.exists("Item", item):
-					item = make_test_item(item)
-					item.is_stock_item = 0
-					item.is_fixed_asset = 1
-					item.asset_naming_series="ACC-ASS-.YYYY.-"
-					item.asset_category = "Computers"
-					item.is_grouped_asset = 1
-					item.auto_create_assets = 1
-					item.save()
-				
-			pi = make_purchase_invoice(
-				supplier="_Test Supplier",
-				company="_Test Company",
-				item_code="_Test Item Group Asset 1",
-				qty=10,
-				rate=1000.0,
-				location="Test Location",
-				do_not_submit=True,
-				update_stock=True
-			)
-			pi.append("items",{
-				"item_code":"_Test Item Group Asset 2",
-				"qty":10,
-				"uom":"Nos",
-				"rate":1000,
-				"asset_location":"Test Location"
-			})
-			pi.taxes_and_charges = "Input GST Out-state - _TC"
-			pi.save()
-			pi.submit()
+		pi = make_purchase_invoice(
+			supplier="_Test Supplier",
+			company="_Test Company",
+			item_code="_Test Item Asset 1",
+			qty=1,
+			rate=1000.0,
+			location="Test Location",
+			do_not_submit=True,
+			update_stock=True
+		)
+		pi.append("items",{
+			"item_code":"_Test Item Asset 2",
+			"qty":1,
+			"uom":"Nos",
+			"rate":1000,
+			"asset_location":"Test Location"
+		})
+		pi.taxes_and_charges = "Input GST Out-state - _TC"
+		pi.save()
+		pi.submit()
+	
+		self.assertTrue(get_gl_entries(pi.doctype, pi.name))
 		
-			self.assertTrue(get_gl_entries(pi.doctype, pi.name))
-			
-			assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
-			self.assertEqual(len(assets_name),2)
-			gross_purchase_amount =0.0 
-			for asset in assets_name:
-				asset_doc = frappe.get_doc("Asset",asset.name)
-				self.assertEqual(pi.name,asset_doc.purchase_invoice)
-				gross_purchase_amount += asset_doc.gross_purchase_amount
-			
-			self.assertEqual(gross_purchase_amount,pi.total)
+		assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
+		gross_purchase_amount =0.0 
+		for asset in assets_name:
+			asset_doc = frappe.get_doc("Asset",asset.name)
+			self.assertEqual(pi.name,asset_doc.purchase_invoice)
+			gross_purchase_amount += asset_doc.gross_purchase_amount
+		
+		self.assertEqual(gross_purchase_amount,pi.total)
   
-	def test_create_subsidy_jv_for_fixed_assets_TC_FA_091(self):
-		from frappe.tests.utils import if_app_installed
+	@if_app_installed("erpnext")
+	def test_multiple_group_asset_purchasing_single_invoice_104(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+			make_test_item,
+			create_records,
+			create_company
+		)
+		create_records('_Test Supplier')
+		create_company()
+		if not frappe.db.exists("Location", "Test Location"):
+			frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
 		
-		if if_app_installed("erpnext"): 
-			from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
-				make_test_item,
-				create_records,
-				create_company,
-			)
-			from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
-			create_records('_Test Supplier')
-			create_company()
-			if not frappe.db.exists("Location", "Test Location"):
-				frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
-			
-			item_list =["_Test Item Asset 1", "_Test Item Asset 2"]
-			
-			for item in item_list:
-				if not frappe.db.exists("Item", item):
-					item = make_test_item(item)
-					item.is_stock_item = 0
-					item.is_fixed_asset = 1
-					item.asset_naming_series="ACC-ASS-.YYYY.-"
-					item.asset_category = "Computers"
-					item.auto_create_assets = 1
-					item.save()
-				
-			pi = make_purchase_invoice(
-				supplier="_Test Supplier",
-				company="_Test Company",
-				item_code="_Test Item Group Asset 1",
-				qty=10,
-				rate=100000.0,
-				location="Test Location",
-				do_not_submit=True,
-				update_stock=True
-			)
-			pi.save()
-			pi.submit()
-			
-			assets_name = frappe.get_value("Asset",{"purchase_invoice":pi.name},"name")
-			
-			jv = make_journal_entry(
-				account1="_Test Bank - _TC",
-				account2="_Test Subsidy - _TC",
-				amount=100000.0,
-				posting_date=pi.posting_date,
-				save=False
-			)
-			jv.accounts[1].reference_type = "Asset"
-			jv.accounts[1].reference_name = assets_name
-			jv.save()
-			jv.submit()
-			expected_gle = [
-				['_Test Bank - _TC', 100000.0, 0.0, jv.posting_date],
-				['_Test Subsidy - _TC', 0.0, 100000.0, jv.posting_date]
-			]
-			check_gl_entries(self,voucher_no=jv.name,expected_gle=expected_gle,posting_date=jv.posting_date,voucher_type=jv.doctype)
-	def test_create_subsidy_jv_for_fixed_assets_partial_ammount_TC_FA_092(self):
-		from frappe.tests.utils import if_app_installed
+		item_list =["_Test Item Group Asset 1", "_Test Item Group Asset 2"]
 		
-		if if_app_installed("erpnext"): 
-			from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
-				make_test_item,
-				create_records,
-				create_company,
-			)
-			from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
-			create_records('_Test Supplier')
-			create_company()
-			if not frappe.db.exists("Location", "Test Location"):
-				frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
+		for item in item_list:
+			if not frappe.db.exists("Item", item):
+				item = make_test_item(item)
+				item.is_stock_item = 0
+				item.is_fixed_asset = 1
+				item.asset_naming_series="ACC-ASS-.YYYY.-"
+				item.asset_category = "Computers"
+				item.is_grouped_asset = 1
+				item.auto_create_assets = 1
+				item.save()
 			
-			item_list =["_Test Item Asset 1", "_Test Item Asset 2"]
+		pi = make_purchase_invoice(
+			supplier="_Test Supplier",
+			company="_Test Company",
+			item_code="_Test Item Group Asset 1",
+			qty=10,
+			rate=1000.0,
+			location="Test Location",
+			do_not_submit=True,
+			update_stock=True
+		)
+		pi.append("items",{
+			"item_code":"_Test Item Group Asset 2",
+			"qty":10,
+			"uom":"Nos",
+			"rate":1000,
+			"asset_location":"Test Location"
+		})
+		pi.save()
+		pi.submit()
+		
+		assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
+		self.assertEqual(len(assets_name),2)
+		for asset in assets_name:
+			asset_doc = frappe.get_doc("Asset",asset.name)
+			self.assertEqual(pi.name,asset_doc.purchase_invoice)
+
+	@if_app_installed("erpnext")
+	def test_multiple_group_asset_purchasing_single_invoice_with_gst_105(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+			make_test_item,
+			create_records,
+			create_company
+		)
+		create_records('_Test Supplier')
+		create_company()
+		if frappe.db.exists("Purchase Taxes and Charges Template", "Input GST Out-state - _TC"):
+			doc = frappe.get_doc("Purchase Taxes and Charges Template", "Input GST Out-state - _TC")
+			doc.taxes[0].rate = 12
+			doc.save()
+		if not frappe.db.exists("Location", "Test Location"):
+			frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
+		
+		item_list =["_Test Item Group Asset 1", "_Test Item Group Asset 2"]
+		
+		for item in item_list:
+			if not frappe.db.exists("Item", item):
+				item = make_test_item(item)
+				item.is_stock_item = 0
+				item.is_fixed_asset = 1
+				item.asset_naming_series="ACC-ASS-.YYYY.-"
+				item.asset_category = "Computers"
+				item.is_grouped_asset = 1
+				item.auto_create_assets = 1
+				item.save()
 			
-			for item in item_list:
-				if not frappe.db.exists("Item", item):
-					item = make_test_item(item)
-					item.is_stock_item = 0
-					item.is_fixed_asset = 1
-					item.asset_naming_series="ACC-ASS-.YYYY.-"
-					item.asset_category = "Computers"
-					item.auto_create_assets = 1
-					item.save()
-				
-			pi = make_purchase_invoice(
-				supplier="_Test Supplier",
-				company="_Test Company",
-				item_code="_Test Item Group Asset 1",
-				qty=10,
-				rate=100000.0,
-				location="Test Location",
-				do_not_submit=True,
-				update_stock=True
-			)
-			pi.save()
-			pi.submit()
-			
-			assets_name = frappe.get_value("Asset",{"purchase_invoice":pi.name},"name")
-			
-			jv = make_journal_entry(
-				account1="_Test Bank - _TC",
-				account2="_Test Subsidy - _TC",
-				amount=100000.0,
-				posting_date=pi.posting_date,
-				save=False
-			)
-			jv.accounts[1].reference_type = "Asset"
-			jv.accounts[1].reference_name = assets_name
-			jv.save()
-			jv.submit()
-			expected_gle = [
-				['_Test Bank - _TC', 100000.0, 0.0, jv.posting_date],
-				['_Test Subsidy - _TC', 0.0, 100000.0, jv.posting_date]
-			]
-			check_gl_entries(self,voucher_no=jv.name,expected_gle=expected_gle,posting_date=jv.posting_date,voucher_type=jv.doctype)
+		pi = make_purchase_invoice(
+			supplier="_Test Supplier",
+			company="_Test Company",
+			item_code="_Test Item Group Asset 1",
+			qty=10,
+			rate=1000.0,
+			location="Test Location",
+			do_not_submit=True,
+			update_stock=True
+		)
+		pi.append("items",{
+			"item_code":"_Test Item Group Asset 2",
+			"qty":10,
+			"uom":"Nos",
+			"rate":1000,
+			"asset_location":"Test Location"
+		})
+		pi.taxes_and_charges = "Input GST Out-state - _TC"
+		pi.save()
+		pi.submit()
 	
+		self.assertTrue(get_gl_entries(pi.doctype, pi.name))
+		
+		assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
+		self.assertEqual(len(assets_name),2)
+		gross_purchase_amount =0.0 
+		for asset in assets_name:
+			asset_doc = frappe.get_doc("Asset",asset.name)
+			self.assertEqual(pi.name,asset_doc.purchase_invoice)
+			gross_purchase_amount += asset_doc.gross_purchase_amount
+		
+		self.assertEqual(gross_purchase_amount,pi.total)
+	@if_app_installed("erpnext")
+	def test_create_subsidy_jv_for_fixed_assets_TC_FA_091(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+			make_test_item,
+			create_records,
+			create_company,
+		)
+		from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
+		create_records('_Test Supplier')
+		create_company()
+		if not frappe.db.exists("Location", "Test Location"):
+			frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
+		
+		item_list =["_Test Item Asset 1", "_Test Item Asset 2"]
+		
+		for item in item_list:
+			if not frappe.db.exists("Item", item):
+				item = make_test_item(item)
+				item.is_stock_item = 0
+				item.is_fixed_asset = 1
+				item.asset_naming_series="ACC-ASS-.YYYY.-"
+				item.asset_category = "Computers"
+				item.auto_create_assets = 1
+				item.save()
+			
+		pi = make_purchase_invoice(
+			supplier="_Test Supplier",
+			company="_Test Company",
+			item_code="_Test Item Group Asset 1",
+			qty=10,
+			rate=100000.0,
+			location="Test Location",
+			do_not_submit=True,
+			update_stock=True
+		)
+		pi.save()
+		pi.submit()
+		
+		assets_name = frappe.get_value("Asset",{"purchase_invoice":pi.name},"name")
+		
+		jv = make_journal_entry(
+			account1="_Test Bank - _TC",
+			account2="_Test Subsidy - _TC",
+			amount=100000.0,
+			posting_date=pi.posting_date,
+			save=False
+		)
+		jv.accounts[1].reference_type = "Asset"
+		jv.accounts[1].reference_name = assets_name
+		jv.save()
+		jv.submit()
+		expected_gle = [
+			['_Test Bank - _TC', 100000.0, 0.0, jv.posting_date],
+			['_Test Subsidy - _TC', 0.0, 100000.0, jv.posting_date]
+		]
+		check_gl_entries(self,voucher_no=jv.name,expected_gle=expected_gle,posting_date=jv.posting_date,voucher_type=jv.doctype)
+  
+	@if_app_installed("erpnext")
+	def test_create_subsidy_jv_for_fixed_assets_partial_ammount_TC_FA_092(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+			make_test_item,
+			create_records,
+			create_company,
+		)
+		from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
+		create_records('_Test Supplier')
+		create_company()
+		if not frappe.db.exists("Location", "Test Location"):
+			frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
+		
+		item_list =["_Test Item Asset 1", "_Test Item Asset 2"]
+		
+		for item in item_list:
+			if not frappe.db.exists("Item", item):
+				item = make_test_item(item)
+				item.is_stock_item = 0
+				item.is_fixed_asset = 1
+				item.asset_naming_series="ACC-ASS-.YYYY.-"
+				item.asset_category = "Computers"
+				item.auto_create_assets = 1
+				item.save()
+			
+		pi = make_purchase_invoice(
+			supplier="_Test Supplier",
+			company="_Test Company",
+			item_code="_Test Item Group Asset 1",
+			qty=10,
+			rate=100000.0,
+			location="Test Location",
+			do_not_submit=True,
+			update_stock=True
+		)
+		pi.save()
+		pi.submit()
+		
+		assets_name = frappe.get_value("Asset",{"purchase_invoice":pi.name},"name")
+		
+		jv = make_journal_entry(
+			account1="_Test Bank - _TC",
+			account2="_Test Subsidy - _TC",
+			amount=100000.0,
+			posting_date=pi.posting_date,
+			save=False
+		)
+		jv.accounts[1].reference_type = "Asset"
+		jv.accounts[1].reference_name = assets_name
+		jv.save()
+		jv.submit()
+		expected_gle = [
+			['_Test Bank - _TC', 100000.0, 0.0, jv.posting_date],
+			['_Test Subsidy - _TC', 0.0, 100000.0, jv.posting_date]
+		]
+		check_gl_entries(self,voucher_no=jv.name,expected_gle=expected_gle,posting_date=jv.posting_date,voucher_type=jv.doctype)
+	
+	@if_app_installed("erpnext")
 	def test_purchase_asset_with_partial_subsidy_grant_credited_to_pl_TC_FA_093(self):
-		from frappe.tests.utils import if_app_installed
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+			make_test_item,
+			create_records,
+			create_company,
+		)
+		from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
+		create_records('_Test Supplier')
+		create_company()
+		if not frappe.db.exists("Location", "Test Location"):
+			frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
 		
-		if if_app_installed("erpnext"): 
-			from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
-				make_test_item,
-				create_records,
-				create_company,
-			)
-			from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
-			create_records('_Test Supplier')
-			create_company()
-			if not frappe.db.exists("Location", "Test Location"):
-				frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
+		item ="_Test Item Asset 1"
+		useful_life = 10
+		if not frappe.db.exists("Item", item):
+			item = make_test_item(item)
+			item.is_stock_item = 0
+			item.is_fixed_asset = 1
+			item.asset_naming_series="ACC-ASS-.YYYY.-"
+			item.asset_category = "Computers"
+			item.auto_create_assets = 1
+			item.save()
 			
-			item ="_Test Item Asset 1"
-			useful_life = 10
-			if not frappe.db.exists("Item", item):
-				item = make_test_item(item)
-				item.is_stock_item = 0
-				item.is_fixed_asset = 1
-				item.asset_naming_series="ACC-ASS-.YYYY.-"
-				item.asset_category = "Computers"
-				item.auto_create_assets = 1
-				item.save()
-				
-			pi = make_purchase_invoice(
-				supplier="_Test Supplier",
-				company="_Test Company",
-				item_code="_Test Item Asset 1",
-				qty=10,
-				rate=150000.0,
-				location="Test Location",
-				do_not_submit=True,
-				update_stock=True
+		pi = make_purchase_invoice(
+			supplier="_Test Supplier",
+			company="_Test Company",
+			item_code="_Test Item Asset 1",
+			qty=10,
+			rate=150000.0,
+			location="Test Location",
+			do_not_submit=True,
+			update_stock=True
+		)
+		pi.save()
+		pi.submit()
+		
+		assets_name = frappe.get_value("Asset",{"purchase_invoice":pi.name},"name")
+		if assets_name:
+			asset_doc = frappe.get_doc("Asset",assets_name)
+			gross_deprication_amount = (800000/asset_doc.gross_purchase_amount) * (asset_doc.gross_purchase_amount/useful_life)
+		if gross_deprication_amount:
+			jv = make_journal_entry(
+				account1="_Test Bank - _TC",
+				account2="_Test Subsidy - _TC",
+				amount=gross_deprication_amount,
+				posting_date=pi.posting_date,
+				save=False
 			)
-			pi.save()
-			pi.submit()
-			
-			assets_name = frappe.get_value("Asset",{"purchase_invoice":pi.name},"name")
-			if assets_name:
-				asset_doc = frappe.get_doc("Asset",assets_name)
-				gross_deprication_amount = (800000/asset_doc.gross_purchase_amount) * (asset_doc.gross_purchase_amount/useful_life)
-			if gross_deprication_amount:
-				jv = make_journal_entry(
-					account1="_Test Bank - _TC",
-					account2="_Test Subsidy - _TC",
-					amount=gross_deprication_amount,
-					posting_date=pi.posting_date,
-					save=False
-				)
-				jv.accounts[1].reference_type = "Asset"
-				jv.accounts[1].reference_name = assets_name
-				jv.save()
-				jv.submit()
-				expected_gle = [
-					['_Test Bank - _TC', gross_deprication_amount, 0.0, jv.posting_date],
-					['_Test Subsidy - _TC', 0.0, gross_deprication_amount, jv.posting_date]
-				]
-				check_gl_entries(self,voucher_no=jv.name,expected_gle=expected_gle,posting_date=jv.posting_date,voucher_type=jv.doctype)
+			jv.accounts[1].reference_type = "Asset"
+			jv.accounts[1].reference_name = assets_name
+			jv.save()
+			jv.submit()
+			expected_gle = [
+				['_Test Bank - _TC', gross_deprication_amount, 0.0, jv.posting_date],
+				['_Test Subsidy - _TC', 0.0, gross_deprication_amount, jv.posting_date]
+			]
+			check_gl_entries(self,voucher_no=jv.name,expected_gle=expected_gle,posting_date=jv.posting_date,voucher_type=jv.doctype)
+   
+	@if_app_installed("erpnext")
 	def test_purchase_asset_with_partial_subsidy_grant_credited_to_pl_refund_TC_FA_094(self):
-		from frappe.tests.utils import if_app_installed
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+			make_test_item,
+			create_records,
+			create_company,
+		)
+		from erpnext.accounts.doctype.journal_entry.journal_entry import make_reverse_journal_entry
+		from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
+		create_records('_Test Supplier')
+		create_company()
+		if not frappe.db.exists("Location", "Test Location"):
+			frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
 		
-		if if_app_installed("erpnext"): 
-			from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
-				make_test_item,
-				create_records,
-				create_company,
-			)
-			from erpnext.accounts.doctype.journal_entry.journal_entry import make_reverse_journal_entry
-			from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
-			create_records('_Test Supplier')
-			create_company()
-			if not frappe.db.exists("Location", "Test Location"):
-				frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
+		item ="_Test Item Asset 1"
+		useful_life = 10
+		if not frappe.db.exists("Item", item):
+			item = make_test_item(item)
+			item.is_stock_item = 0
+			item.is_fixed_asset = 1
+			item.asset_naming_series="ACC-ASS-.YYYY.-"
+			item.asset_category = "Computers"
+			item.auto_create_assets = 1
+			item.save()
 			
-			item ="_Test Item Asset 1"
-			useful_life = 10
-			if not frappe.db.exists("Item", item):
-				item = make_test_item(item)
-				item.is_stock_item = 0
-				item.is_fixed_asset = 1
-				item.asset_naming_series="ACC-ASS-.YYYY.-"
-				item.asset_category = "Computers"
-				item.auto_create_assets = 1
-				item.save()
-				
-			pi = make_purchase_invoice(
-				supplier="_Test Supplier",
-				company="_Test Company",
-				item_code="_Test Item Asset 1",
-				qty=10,
-				rate=150000.0,
-				location="Test Location",
-				do_not_submit=True,
-				update_stock=True
+		pi = make_purchase_invoice(
+			supplier="_Test Supplier",
+			company="_Test Company",
+			item_code="_Test Item Asset 1",
+			qty=10,
+			rate=150000.0,
+			location="Test Location",
+			do_not_submit=True,
+			update_stock=True
+		)
+		pi.save()
+		pi.submit()
+		
+		assets_name = frappe.get_value("Asset",{"purchase_invoice":pi.name},"name")
+		if assets_name:
+			asset_doc = frappe.get_doc("Asset",assets_name)
+			gross_deprication_amount = (800000/asset_doc.gross_purchase_amount) * (asset_doc.gross_purchase_amount/useful_life)
+		if gross_deprication_amount:
+			jv = make_journal_entry(
+				account1="_Test Bank - _TC",
+				account2="_Test Subsidy - _TC",
+				amount=gross_deprication_amount,
+				posting_date=pi.posting_date,
+				save=False
 			)
-			pi.save()
-			pi.submit()
-			
-			assets_name = frappe.get_value("Asset",{"purchase_invoice":pi.name},"name")
-			if assets_name:
-				asset_doc = frappe.get_doc("Asset",assets_name)
-				gross_deprication_amount = (800000/asset_doc.gross_purchase_amount) * (asset_doc.gross_purchase_amount/useful_life)
-			if gross_deprication_amount:
-				jv = make_journal_entry(
-					account1="_Test Bank - _TC",
-					account2="_Test Subsidy - _TC",
-					amount=gross_deprication_amount,
-					posting_date=pi.posting_date,
-					save=False
-				)
-				jv.accounts[1].reference_type = "Asset"
-				jv.accounts[1].reference_name = assets_name
-				jv.save()
-				jv.submit()
-				reverse_jv = make_reverse_journal_entry(jv.name)
-				reverse_jv.posting_date = jv.posting_date
-				reverse_jv.save()
-				reverse_jv.submit()
-				expected_gle = [
-					['_Test Bank - _TC', 0.0,gross_deprication_amount, jv.posting_date],
-					['_Test Subsidy - _TC', gross_deprication_amount,0.0, jv.posting_date]
-				]
-				check_gl_entries(self,voucher_no=reverse_jv.name,expected_gle=expected_gle,posting_date=reverse_jv.posting_date,voucher_type=jv.doctype)
+			jv.accounts[1].reference_type = "Asset"
+			jv.accounts[1].reference_name = assets_name
+			jv.save()
+			jv.submit()
+			reverse_jv = make_reverse_journal_entry(jv.name)
+			reverse_jv.posting_date = jv.posting_date
+			reverse_jv.save()
+			reverse_jv.submit()
+			expected_gle = [
+				['_Test Bank - _TC', 0.0,gross_deprication_amount, jv.posting_date],
+				['_Test Subsidy - _TC', gross_deprication_amount,0.0, jv.posting_date]
+			]
+			check_gl_entries(self,voucher_no=reverse_jv.name,expected_gle=expected_gle,posting_date=reverse_jv.posting_date,voucher_type=jv.doctype)
 	
 def get_gl_entries(doctype, docname):
 	gl_entry = frappe.qb.DocType("GL Entry")

--- a/assets/assets/doctype/asset/test_asset.py
+++ b/assets/assets/doctype/asset/test_asset.py
@@ -5792,6 +5792,75 @@ class TestDepreciationBasics(AssetSetup):
 				['_Test Subsidy - _TC', gross_deprication_amount,0.0, jv.posting_date]
 			]
 			check_gl_entries(self,voucher_no=reverse_jv.name,expected_gle=expected_gle,posting_date=reverse_jv.posting_date,voucher_type=jv.doctype)
+	def test_journal_entry_against_asset_TC_FA_095(self):
+		frappe.set_user("Administrator")
+		get_details = create_company_and_supplier()
+		company = get_details.get("parent_company")
+		frappe.db.set_value("Company", company, "depreciation_cost_center", "Main - TC-1")
+		asset_category = get_asset_category()
+		location = get_location()
+
+		item = make_test_item("test_asset_item_1")
+		item.is_stock_item = 0
+		item.is_fixed_asset = 1
+		item.is_grouped_asset = 1
+		item.asset_category = asset_category
+		item.save()
+
+		pr = create_purchase_receipt(item)
+
+		asset = create_assets(company, location, pr, item.item_code)
+
+		je = frappe.get_doc(
+			{
+				"doctype": "Journal Entry",
+				"voucher_type": "Journal Entry",
+				"company": company,
+				"posting_date": today(),
+				"accounts": [
+					{
+						"account": get_or_create_account(company, "Deferred Revenue Grant Account"),
+						"debit_in_account_currency": 500000,
+						"credit_in_account_currency":0,
+						"cost_center": "Main - TC-1",
+						"reference_type": "Asset",
+						"reference_name": asset
+					},
+					{
+						"account": get_or_create_account(company, "Profit & Loss"),
+						"debit_in_account_currency": 300000,
+						"credit_in_account_currency":0,
+						"cost_center": "Main - TC-1",
+						"reference_type": "Asset",
+						"reference_name": asset
+					},
+					{
+						"account": get_or_create_account(company, "To Bank"),
+						"debit_in_account_currency": 0,
+						"credit_in_account_currency":800000,
+						"cost_center": "Main - TC-1",
+						"reference_type": "Asset",
+						"reference_name": asset
+					},
+				],
+			}
+		)
+		je.insert()
+		je.submit()
+		self.assertEqual(je.docstatus, 1)
+
+		je_gle_entries = frappe.get_all("GL Entry", filters={"voucher_no": je.name}, fields=["account", "debit", "credit"])
+
+		expected_si_entries = {
+			"To Bank - TC-1": {"debit": 0, "credit": 800000},
+			"Profit & Loss - TC-1": {"debit": 300000, "credit": 0},
+			"Deferred Revenue Grant Account - TC-1": {"debit": 500000, "credit": 0},
+		}
+
+		for entry in je_gle_entries:
+			self.assertEqual(entry["debit"], expected_si_entries.get(entry["account"], {}).get("debit", 0))
+			self.assertEqual(entry["credit"], expected_si_entries.get(entry["account"], {}).get("credit", 0))
+
 	def test_journal_entry_against_asset_refund_TC_FA_096(self):
 		frappe.set_user("Administrator")
 		get_details = create_company_and_supplier()

--- a/assets/assets/doctype/asset/test_asset.py
+++ b/assets/assets/doctype/asset/test_asset.py
@@ -5159,7 +5159,229 @@ class TestDepreciationBasics(AssetSetup):
 		self.assertTrue(get_gl_entries("Purchase Receipt", pr.name))
 
 	
-
+	def test_multiple_asset_purchasing_single_invoice_TC_FA_102(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+			make_test_item,
+			create_records,
+			create_company
+		)
+		create_records('_Test Supplier')
+		create_company()
+		if not frappe.db.exists("Location", "Test Location"):
+			frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
+	
+		item_list =["_Test Item Asset 1", "_Test Item Asset 2"]
+		
+			
+		for item in item_list:
+			if not frappe.db.exists("Item", item):
+				item = make_test_item(item)
+				item.is_stock_item = 0
+				item.is_fixed_asset = 1
+				item.asset_naming_series="ACC-ASS-.YYYY.-"
+				item.asset_category = "Computers"
+				item.is_grouped_asset = 1
+				item.auto_create_assets = 1
+				item.save()
+		
+		pi = make_purchase_invoice(
+			supplier="_Test Supplier",
+			company="_Test Company",
+			item_code="_Test Item Asset 1",
+			qty=1,
+			rate=100.0,
+			location="Test Location",
+			do_not_submit=True,
+			update_stock=True
+   		)
+		pi.append("items",{
+			"item_code":"_Test Item Asset 2",
+			"qty":1,
+			"uom":"Nos",
+			"rate":1000,
+			"asset_location":"Test Location"
+		})
+		pi.save()
+		pi.submit()
+	    
+		assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
+		
+		for asset in assets_name:
+			asset_doc = frappe.get_doc("Asset",asset.name)
+			self.assertEqual(pi.name,asset_doc.purchase_invoice)
+   
+	def test_multiple_asset_purchasing_single_invoice_with_gst_TC_FA_103(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+			make_test_item,
+			create_records,
+			create_company
+		)
+		create_records('_Test Supplier')
+		create_company()
+		if frappe.db.exists("Purchase Taxes and Charges Template", "Input GST Out-state - _TC"):
+			doc = frappe.get_doc("Purchase Taxes and Charges Template", "Input GST Out-state - _TC")
+			doc.taxes[0].rate = 12
+			doc.save()
+		if not frappe.db.exists("Location", "Test Location"):
+			frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
+	
+		item_list =["_Test Item Asset 1", "_Test Item Asset 2"]
+		
+			
+		for item in item_list:
+			if not frappe.db.exists("Item", item):
+				item = make_test_item(item)
+				item.is_stock_item = 0
+				item.is_fixed_asset = 1
+				item.asset_naming_series="ACC-ASS-.YYYY.-"
+				item.asset_category = "Computers"
+				item.is_grouped_asset = 1
+				item.auto_create_assets = 1
+				item.save()
+		
+		pi = make_purchase_invoice(
+			supplier="_Test Supplier",
+			company="_Test Company",
+			item_code="_Test Item Asset 1",
+			qty=1,
+			rate=1000.0,
+			location="Test Location",
+			do_not_submit=True,
+			update_stock=True
+   		)
+		pi.append("items",{
+			"item_code":"_Test Item Asset 2",
+			"qty":1,
+			"uom":"Nos",
+			"rate":1000,
+			"asset_location":"Test Location"
+		})
+		pi.taxes_and_charges = "Input GST Out-state - _TC"
+		pi.save()
+		pi.submit()
+	
+		self.assertTrue(get_gl_entries(pi.doctype, pi.name))
+		
+		assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
+		gross_purchase_amount =0.0 
+		for asset in assets_name:
+			asset_doc = frappe.get_doc("Asset",asset.name)
+			self.assertEqual(pi.name,asset_doc.purchase_invoice)
+			gross_purchase_amount += asset_doc.gross_purchase_amount
+		
+		self.assertEqual(gross_purchase_amount,pi.total)
+	
+	def test_multiple_group_asset_purchasing_single_invoice_104(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+			make_test_item,
+			create_records,
+			create_company
+		)
+		create_records('_Test Supplier')
+		create_company()
+		if not frappe.db.exists("Location", "Test Location"):
+			frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
+		
+		item_list =["_Test Item Group Asset 1", "_Test Item Group Asset 2"]
+		
+		for item in item_list:
+			if not frappe.db.exists("Item", item):
+				item = make_test_item(item)
+				item.is_stock_item = 0
+				item.is_fixed_asset = 1
+				item.asset_naming_series="ACC-ASS-.YYYY.-"
+				item.asset_category = "Computers"
+				item.is_grouped_asset = 1
+				item.auto_create_assets = 1
+				item.save()
+			
+		pi = make_purchase_invoice(
+			supplier="_Test Supplier",
+			company="_Test Company",
+			item_code="_Test Item Group Asset 1",
+			qty=10,
+			rate=1000.0,
+			location="Test Location",
+			do_not_submit=True,
+			update_stock=True
+   		)
+		pi.append("items",{
+			"item_code":"_Test Item Group Asset 2",
+			"qty":10,
+			"uom":"Nos",
+			"rate":1000,
+			"asset_location":"Test Location"
+		})
+		pi.save()
+		pi.submit()
+	    
+		assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
+		self.assertEqual(len(assets_name),2)
+		for asset in assets_name:
+			asset_doc = frappe.get_doc("Asset",asset.name)
+			self.assertEqual(pi.name,asset_doc.purchase_invoice)
+   
+   
+	def test_multiple_group_asset_purchasing_single_invoice_with_gst_105(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+			make_test_item,
+			create_records,
+			create_company
+		)
+		create_records('_Test Supplier')
+		create_company()
+		if frappe.db.exists("Purchase Taxes and Charges Template", "Input GST Out-state - _TC"):
+			doc = frappe.get_doc("Purchase Taxes and Charges Template", "Input GST Out-state - _TC")
+			doc.taxes[0].rate = 12
+			doc.save()
+		if not frappe.db.exists("Location", "Test Location"):
+			frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
+		
+		item_list =["_Test Item Group Asset 1", "_Test Item Group Asset 2"]
+		
+		for item in item_list:
+			if not frappe.db.exists("Item", item):
+				item = make_test_item(item)
+				item.is_stock_item = 0
+				item.is_fixed_asset = 1
+				item.asset_naming_series="ACC-ASS-.YYYY.-"
+				item.asset_category = "Computers"
+				item.is_grouped_asset = 1
+				item.auto_create_assets = 1
+				item.save()
+			
+		pi = make_purchase_invoice(
+			supplier="_Test Supplier",
+			company="_Test Company",
+			item_code="_Test Item Group Asset 1",
+			qty=10,
+			rate=1000.0,
+			location="Test Location",
+			do_not_submit=True,
+			update_stock=True
+   		)
+		pi.append("items",{
+			"item_code":"_Test Item Group Asset 2",
+			"qty":10,
+			"uom":"Nos",
+			"rate":1000,
+			"asset_location":"Test Location"
+		})
+		pi.taxes_and_charges = "Input GST Out-state - _TC"
+		pi.save()
+		pi.submit()
+	
+		self.assertTrue(get_gl_entries(pi.doctype, pi.name))
+	    
+		assets_name = frappe.get_list("Asset",filters={"purchase_invoice":pi.name},fields=["name"])
+		self.assertEqual(len(assets_name),2)
+		gross_purchase_amount =0.0 
+		for asset in assets_name:
+			asset_doc = frappe.get_doc("Asset",asset.name)
+			self.assertEqual(pi.name,asset_doc.purchase_invoice)
+			gross_purchase_amount += asset_doc.gross_purchase_amount
+		
+		self.assertEqual(gross_purchase_amount,pi.total)
 def get_gl_entries(doctype, docname):
 	gl_entry = frappe.qb.DocType("GL Entry")
 	return (

--- a/assets/assets/doctype/asset/test_asset.py
+++ b/assets/assets/doctype/asset/test_asset.py
@@ -5792,6 +5792,65 @@ class TestDepreciationBasics(AssetSetup):
 				['_Test Subsidy - _TC', gross_deprication_amount,0.0, jv.posting_date]
 			]
 			check_gl_entries(self,voucher_no=reverse_jv.name,expected_gle=expected_gle,posting_date=reverse_jv.posting_date,voucher_type=jv.doctype)
+	def test_journal_entry_against_asset_refund_TC_FA_096(self):
+		frappe.set_user("Administrator")
+		get_details = create_company_and_supplier()
+		company = get_details.get("parent_company")
+		frappe.db.set_value("Company", company, "depreciation_cost_center", "Main - TC-1")
+		asset_category = get_asset_category()
+		location = get_location()
+
+		item = make_test_item("test_asset_item_1")
+		item.is_stock_item = 0
+		item.is_fixed_asset = 1
+		item.is_grouped_asset = 1
+		item.asset_category = asset_category
+		item.save()
+
+		pr = create_purchase_receipt(item)
+
+		asset = create_assets(company, location, pr, item.item_code)
+
+		je = frappe.get_doc(
+			{
+				"doctype": "Journal Entry",
+				"voucher_type": "Journal Entry",
+				"company": company,
+				"posting_date": today(),
+				"accounts": [
+					{
+						"account": get_or_create_account(company, "Profit & Loss"),
+						"debit_in_account_currency": 0,
+						"credit_in_account_currency":800000,
+						"cost_center": "Main - TC-1",
+						"reference_type": "Asset",
+						"reference_name": asset
+					},
+					{
+						"account": get_or_create_account(company, "To Bank"),
+						"debit_in_account_currency": 800000,
+						"credit_in_account_currency":0,
+						"cost_center": "Main - TC-1",
+						"reference_type": "Asset",
+						"reference_name": asset
+					},
+				],
+			}
+		)
+		je.insert()
+		je.submit()
+		self.assertEqual(je.docstatus, 1)
+
+		je_gle_entries = frappe.get_all("GL Entry", filters={"voucher_no": je.name}, fields=["account", "debit", "credit"])
+
+		expected_si_entries = {
+			"To Bank - TC-1": {"debit": 800000, "credit": 0},
+			"Profit & Loss - TC-1": {"debit": 0, "credit": 800000},
+		}
+
+		for entry in je_gle_entries:
+			self.assertEqual(entry["debit"], expected_si_entries.get(entry["account"], {}).get("debit", 0))
+			self.assertEqual(entry["credit"], expected_si_entries.get(entry["account"], {}).get("credit", 0))
 	
 def get_gl_entries(doctype, docname):
 	gl_entry = frappe.qb.DocType("GL Entry")

--- a/assets/assets/doctype/asset/test_asset.py
+++ b/assets/assets/doctype/asset/test_asset.py
@@ -5410,7 +5410,7 @@ class TestDepreciationBasics(AssetSetup):
 			if not frappe.db.exists("Location", "Test Location"):
 				frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
 			
-			item_list =["_Test Item Group Asset 1", "_Test Item Group Asset 2"]
+			item_list =["_Test Item Asset 1", "_Test Item Asset 2"]
 			
 			for item in item_list:
 				if not frappe.db.exists("Item", item):
@@ -5419,7 +5419,6 @@ class TestDepreciationBasics(AssetSetup):
 					item.is_fixed_asset = 1
 					item.asset_naming_series="ACC-ASS-.YYYY.-"
 					item.asset_category = "Computers"
-					item.is_grouped_asset = 1
 					item.auto_create_assets = 1
 					item.save()
 				
@@ -5469,7 +5468,7 @@ class TestDepreciationBasics(AssetSetup):
 			if not frappe.db.exists("Location", "Test Location"):
 				frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
 			
-			item_list =["_Test Item Group Asset 1", "_Test Item Group Asset 2"]
+			item_list =["_Test Item Asset 1", "_Test Item Asset 2"]
 			
 			for item in item_list:
 				if not frappe.db.exists("Item", item):
@@ -5478,7 +5477,6 @@ class TestDepreciationBasics(AssetSetup):
 					item.is_fixed_asset = 1
 					item.asset_naming_series="ACC-ASS-.YYYY.-"
 					item.asset_category = "Computers"
-					item.is_grouped_asset = 1
 					item.auto_create_assets = 1
 					item.save()
 				
@@ -5513,7 +5511,133 @@ class TestDepreciationBasics(AssetSetup):
 				['_Test Subsidy - _TC', 0.0, 100000.0, jv.posting_date]
 			]
 			check_gl_entries(self,voucher_no=jv.name,expected_gle=expected_gle,posting_date=jv.posting_date,voucher_type=jv.doctype)
+	
+	def test_purchase_asset_with_partial_subsidy_grant_credited_to_pl_TC_FA_093(self):
+		from frappe.tests.utils import if_app_installed
+		
+		if if_app_installed("erpnext"): 
+			from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+				make_test_item,
+				create_records,
+				create_company,
+			)
+			from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
+			create_records('_Test Supplier')
+			create_company()
+			if not frappe.db.exists("Location", "Test Location"):
+				frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
 			
+			item ="_Test Item Asset 1"
+			useful_life = 10
+			if not frappe.db.exists("Item", item):
+				item = make_test_item(item)
+				item.is_stock_item = 0
+				item.is_fixed_asset = 1
+				item.asset_naming_series="ACC-ASS-.YYYY.-"
+				item.asset_category = "Computers"
+				item.auto_create_assets = 1
+				item.save()
+				
+			pi = make_purchase_invoice(
+				supplier="_Test Supplier",
+				company="_Test Company",
+				item_code="_Test Item Asset 1",
+				qty=10,
+				rate=150000.0,
+				location="Test Location",
+				do_not_submit=True,
+				update_stock=True
+			)
+			pi.save()
+			pi.submit()
+			
+			assets_name = frappe.get_value("Asset",{"purchase_invoice":pi.name},"name")
+			if assets_name:
+				asset_doc = frappe.get_doc("Asset",assets_name)
+				gross_deprication_amount = (800000/asset_doc.gross_purchase_amount) * (asset_doc.gross_purchase_amount/useful_life)
+			if gross_deprication_amount:
+				jv = make_journal_entry(
+					account1="_Test Bank - _TC",
+					account2="_Test Subsidy - _TC",
+					amount=gross_deprication_amount,
+					posting_date=pi.posting_date,
+					save=False
+				)
+				jv.accounts[1].reference_type = "Asset"
+				jv.accounts[1].reference_name = assets_name
+				jv.save()
+				jv.submit()
+				expected_gle = [
+					['_Test Bank - _TC', gross_deprication_amount, 0.0, jv.posting_date],
+					['_Test Subsidy - _TC', 0.0, gross_deprication_amount, jv.posting_date]
+				]
+				check_gl_entries(self,voucher_no=jv.name,expected_gle=expected_gle,posting_date=jv.posting_date,voucher_type=jv.doctype)
+	def test_purchase_asset_with_partial_subsidy_grant_credited_to_pl_refund_TC_FA_094(self):
+		from frappe.tests.utils import if_app_installed
+		
+		if if_app_installed("erpnext"): 
+			from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+				make_test_item,
+				create_records,
+				create_company,
+			)
+			from erpnext.accounts.doctype.journal_entry.journal_entry import make_reverse_journal_entry
+			from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
+			create_records('_Test Supplier')
+			create_company()
+			if not frappe.db.exists("Location", "Test Location"):
+				frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
+			
+			item ="_Test Item Asset 1"
+			useful_life = 10
+			if not frappe.db.exists("Item", item):
+				item = make_test_item(item)
+				item.is_stock_item = 0
+				item.is_fixed_asset = 1
+				item.asset_naming_series="ACC-ASS-.YYYY.-"
+				item.asset_category = "Computers"
+				item.auto_create_assets = 1
+				item.save()
+				
+			pi = make_purchase_invoice(
+				supplier="_Test Supplier",
+				company="_Test Company",
+				item_code="_Test Item Asset 1",
+				qty=10,
+				rate=150000.0,
+				location="Test Location",
+				do_not_submit=True,
+				update_stock=True
+			)
+			pi.save()
+			pi.submit()
+			
+			assets_name = frappe.get_value("Asset",{"purchase_invoice":pi.name},"name")
+			if assets_name:
+				asset_doc = frappe.get_doc("Asset",assets_name)
+				gross_deprication_amount = (800000/asset_doc.gross_purchase_amount) * (asset_doc.gross_purchase_amount/useful_life)
+			if gross_deprication_amount:
+				jv = make_journal_entry(
+					account1="_Test Bank - _TC",
+					account2="_Test Subsidy - _TC",
+					amount=gross_deprication_amount,
+					posting_date=pi.posting_date,
+					save=False
+				)
+				jv.accounts[1].reference_type = "Asset"
+				jv.accounts[1].reference_name = assets_name
+				jv.save()
+				jv.submit()
+				reverse_jv = make_reverse_journal_entry(jv.name)
+				reverse_jv.posting_date = jv.posting_date
+				reverse_jv.save()
+				reverse_jv.submit()
+				expected_gle = [
+					['_Test Bank - _TC', 0.0,gross_deprication_amount, jv.posting_date],
+					['_Test Subsidy - _TC', gross_deprication_amount,0.0, jv.posting_date]
+				]
+				check_gl_entries(self,voucher_no=reverse_jv.name,expected_gle=expected_gle,posting_date=reverse_jv.posting_date,voucher_type=jv.doctype)
+	
 def get_gl_entries(doctype, docname):
 	gl_entry = frappe.qb.DocType("GL Entry")
 	return (


### PR DESCRIPTION
test_multiple_asset_purchasing_single_invoice_TC_FA_102
The required supplier and company records exist.
Test assets (_Test Item Asset 1 and _Test Item Asset 2) are created if they do not exist.
A purchase invoice is created with both assets.
The system correctly links the created assets to the purchase invoice.
The assets exist in the system with the correct purchase invoice reference.

2. test_multiple_asset_purchasing_single_invoice_with_gst_TC_FA_103
The necessary supplier, company, and tax templates exist and are properly configured.
The test assets (_Test Item Asset 1 and _Test Item Asset 2) exist or are created.
A purchase invoice is generated with GST applied.
The system generates appropriate General Ledger (GL) entries for the invoice.
The created assets are linked correctly to the purchase invoice.
The gross purchase amount of the assets matches the total of the invoice.

3. test_multiple_group_asset_purchasing_single_invoice_104
The required supplier, company, and location records exist.
Test group assets (_Test Item Group Asset 1 and _Test Item Group Asset 2) are created if they do not exist.
A purchase invoice is created for 10 units of each grouped asset.
The system correctly creates asset records for the grouped assets.
The system links the created assets to the purchase invoice.

4. test_multiple_group_asset_purchasing_single_invoice_with_gst_105
The necessary supplier, company, and tax templates exist and are properly configured.
The test group assets (_Test Item Group Asset 1 and _Test Item Group Asset 2) exist or are created.
A purchase invoice is generated with GST applied.
The system generates appropriate General Ledger (GL) entries.
The created assets are linked correctly to the purchase invoice.
The gross purchase amount of the assets matches the total of the invoice


Test Case: Create Subsidy Journal Entry for Fixed Assets (TC_FA_091)
Added a test case to verify the creation of a Journal Entry (JV) for Subsidy related to Fixed Assets. Ensures that a subsidy-related journal entry is correctly linked to an asset purchased via a Purchase Invoice, and the General Ledger (GL) entries are properly recorded.

Test Case: Create Subsidy Journal Entry for Fixed Assets - Partial Amount (TC_FA_092)
Implemented a test case to validate the Journal Entry (JV) for a Partial Subsidy on Fixed Assets. This test confirms that even when a partial subsidy is applied, the journal entry is correctly linked to the asset, and the GL entries are accurately recorded.

Test Case: Purchase Asset with Partial Subsidy Grant Credited to P&L (TC_FA_093)
Developed a test case for purchasing an asset with a partial subsidy where the grant is credited to the Profit & Loss account. This test checks that depreciation is properly calculated based on the useful life of the asset, and the subsidy is allocated accordingly in the Journal Entry (JV) and GL Entries.

Test Case: Purchase Asset with Partial Subsidy Grant Credited to P&L - Refund (TC_FA_094)
Added a test case to handle the scenario where a partial subsidy grant credited to P&L is refunded. This involves creating a reverse journal entry to adjust the previously recorded subsidy amount, ensuring accurate reflection in the General Ledger (GL) entries.







