### PR TITLE
test: Test-cases-on-asset-repair-doctype

### DIFF
--- a/assets/assets/doctype/asset/test_asset.py
+++ b/assets/assets/doctype/asset/test_asset.py
@@ -1999,12 +1999,10 @@ class TestAsset(AssetSetup):
 			}]
 		}).insert()
 		target_asset.submit()
-		frappe.db.commit()
 
 		# Cancel the asset
 		target_asset.reload()
 		target_asset.cancel()
-		frappe.db.commit()
 
 		# Verify that asset depreciation schedule is also cancelled
 		depreciation_schedules = frappe.get_all("Asset Depreciation Schedule", 
@@ -2013,7 +2011,6 @@ class TestAsset(AssetSetup):
 		for schedule in depreciation_schedules:
 			dep_doc = frappe.get_doc("Asset Depreciation Schedule", schedule.name)
 			dep_doc.cancel()
-			frappe.db.commit()
 
 		# Ensure asset and schedules are in cancelled state
 		target_asset.reload()

--- a/assets/assets/doctype/asset/test_asset.py
+++ b/assets/assets/doctype/asset/test_asset.py
@@ -1880,17 +1880,98 @@ class TestAsset(AssetSetup):
 
 		# Ensure the item exists or create it
 		if not frappe.db.exists("Item", item_code):
-			frappe.get_doc({
+			item_data = {
 				"doctype": "Item",
 				"item_code": item_code,
 				"item_name": item_code,
 				"item_group": "Products",
 				"is_fixed_asset": 1,  # Marking as fixed asset
 				"is_stock_item": 0,
-				"gst_hsn_code": "01011010",
 				"asset_naming_series": "ACC-ASS-.YYYY.-",
 				"asset_category": "Test_Category"
-			}).insert()
+			}
+
+			# Check if 'gst_hsn_code' exists in Item doctype
+			if frappe.db.has_column("Item", "gst_hsn_code"):
+				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
+
+			frappe.get_doc(item_data).insert()
+
+		target_asset = frappe.get_doc({
+			"doctype": "Asset",
+			"company": company,
+			"item_code": item_code,
+			"asset_name": item_code,
+			"asset_category": "Test_Category",
+			"location": "Test Location",
+			"is_existing_asset": 1,
+			"available_for_use_date": "2024-04-02",
+			"gross_purchase_amount": "12000",
+			"asset_quantity": 1,
+			"purchase_date": "2024-04-01",
+			"calculate_depreciation": 1,
+			"opening_accumulated_depreciation": "7000",
+			"opening_number_of_booked_depreciations": 7,
+			"finance_books": [{
+				"finance_book": "2024-2025",
+				"frequency_of_depreciation": 1,
+				"depreciation_method": "Written Down Value",
+				"depreciation_start_date": "2025-06-01",
+				"total_number_of_depreciations": 12,
+				"total_number_of_booked_depreciations": 7,
+				"value_after_depreciation": 5000
+			}]
+		}).insert()
+		target_asset.submit()
+		frappe.db.commit()
+
+		# Cancel the asset
+		target_asset.reload()
+		target_asset.cancel()
+		frappe.db.commit()
+
+		# Verify that asset depreciation schedule is also cancelled
+		depreciation_schedules = frappe.get_all("Asset Depreciation Schedule", 
+			filters={"asset": target_asset.name, "docstatus": 1})
+		
+		for schedule in depreciation_schedules:
+			dep_doc = frappe.get_doc("Asset Depreciation Schedule", schedule.name)
+			dep_doc.cancel()
+			frappe.db.commit()
+
+		# Ensure asset and schedules are in cancelled state
+		target_asset.reload()
+		assert target_asset.docstatus == 2, "Asset was not cancelled"
+		for schedule in depreciation_schedules:
+			dep_doc.reload()
+			assert dep_doc.docstatus == 2, f"Depreciation Schedule {dep_doc.name} was not cancelled"
+
+	# TC_FA_101
+	def test_cancel_asset_and_manual_asset_depreciation_schedule_TC_FA_101(self):
+		item_code = "Test_Asset (Existing Asset)"
+		company = "_Test Company"
+
+		if not frappe.db.exists("Company", company):
+			create_child_company()
+
+		# Ensure the item exists or create it
+		if not frappe.db.exists("Item", item_code):
+			item_data = {
+				"doctype": "Item",
+				"item_code": item_code,
+				"item_name": item_code,
+				"item_group": "Products",
+				"is_fixed_asset": 1,  # Marking as fixed asset
+				"is_stock_item": 0,
+				"asset_naming_series": "ACC-ASS-.YYYY.-",
+				"asset_category": "Test_Category"
+			}
+
+			# Check if 'gst_hsn_code' exists in Item doctype
+			if frappe.db.has_column("Item", "gst_hsn_code"):
+				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
+
+			frappe.get_doc(item_data).insert()
 
 		target_asset = frappe.get_doc({
 			"doctype": "Asset",

--- a/assets/assets/doctype/asset_repair/test_asset_repair.py
+++ b/assets/assets/doctype/asset_repair/test_asset_repair.py
@@ -191,7 +191,6 @@ class TestAssetRepair(unittest.TestCase):
 					}]
 		}).insert()
 		target_asset.submit()
-		frappe.db.commit()
 
 		company = "_Test Company"
 		supplier = "_Test Supplier"
@@ -208,7 +207,6 @@ class TestAssetRepair(unittest.TestCase):
 			
 
 		}).insert()
-		frappe.db.commit()
 	
 
 	# TC_FA_138
@@ -270,7 +268,6 @@ class TestAssetRepair(unittest.TestCase):
 					}]
 		}).insert()
 		target_asset.submit()
-		frappe.db.commit()
 
 		company = "_Test Company"
 		supplier = "_Test Supplier"
@@ -288,7 +285,6 @@ class TestAssetRepair(unittest.TestCase):
 
 		}).insert()
 		asset_repair.submit()
-		frappe.db.commit()
 	
 	# TC_FA_139
 	def test_service_item_asset_repair_submit_on_complete_status_TC_FA_139(self):
@@ -352,7 +348,6 @@ class TestAssetRepair(unittest.TestCase):
 			]
 		}).insert()
 		target_asset.submit()
-		frappe.db.commit()
 
 		# Create Purchase Invoice (for Non-Stock Asset)
 		supplier = "_Test Supplier"
@@ -377,7 +372,6 @@ class TestAssetRepair(unittest.TestCase):
 		})
 		pi.insert()
 		pi.submit()
-		frappe.db.commit()
 
 		# Create Asset Repair
 		asset_repair = frappe.get_doc({
@@ -396,7 +390,6 @@ class TestAssetRepair(unittest.TestCase):
 			]
 		}).insert()
 		asset_repair.submit()
-		frappe.db.commit()
 
 	def test_update_status(self):
 		asset = create_asset(submit=1)

--- a/assets/assets/doctype/asset_repair/test_asset_repair.py
+++ b/assets/assets/doctype/asset_repair/test_asset_repair.py
@@ -132,6 +132,314 @@ class TestAssetRepair(unittest.TestCase):
 		asset_repair.submit()
 		frappe.db.commit()
 
+	# TC_FA_137
+	def test_pending_asset_repair_submit_on_complete_status_TC_FA_137(self):
+
+		company = "_Test Company"
+		item_code = "Test_asset_repair_item1"
+		asset_name = "Test_asset_maintainance"
+		# Ensure the company exists
+		if not frappe.db.exists("Company", company):
+			create_child_company()
+
+		# Create the item if it doesn't exist
+		if not frappe.db.exists("Item", item_code):
+			item_data = {
+				"doctype": "Item",
+				"item_code": item_code,
+				"item_name": item_code,
+				"is_stock_item": 0,
+				"is_fixed_asset": 1,  # Marking as fixed asset
+				"asset_naming_series": "ACC-ASS-.YYYY.-",
+				"asset_category": "Test_Category",
+				"item_group":"Raw Material",
+				"stock_uom":"Nos",
+
+			}
+
+			# Check if 'gst_hsn_code' exists in Item doctype
+			if frappe.db.has_column("Item", "gst_hsn_code"):
+				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
+			frappe.get_doc(item_data).insert()
+		
+		target_asset = frappe.get_doc({
+			"doctype": "Asset",
+			"company": company,
+			"item_code": item_code,
+			"asset_name": item_code,
+			"asset_category":"Test_Category",
+			"location": "Test Location",
+			"is_existing_asset":1,
+			"available_for_use_date":"02-04-2024",
+			"gross_purchase_amount":8000,
+			"total_asset":8000,
+			"asset_quantity":2,
+			"purchase_date":"01-04-2024",
+			"calculate_depreciation":0,
+			"opening_accumulated_depreciation":8000,
+			"opening_number_of_booked_depreciations":8,
+			"is_fully_depreciated":1,
+			"maintenance_required":1,
+			"finance_books":[{
+				"finance_book":"2024-2025",
+				"frequency_of_depreciation":1,
+				"depreciation_method":"Straight Line",
+				"depreciation_start_date":"01-06-2025",
+				"total_number_of_depreciations":12,
+				"total_number_of_booked_depreciations":7,
+				"value_after_depreciation":5000
+					}]
+		}).insert()
+		target_asset.submit()
+		frappe.db.commit()
+
+		company = "_Test Company"
+		supplier = "_Test Supplier"
+		qty, rate, warehouse = 1, 500, "_Test Warehouse - _TC"
+		required_by_date = nowdate()
+
+		# pi = frappe.get_doc({
+		# 	"doctype": "Purchase Invoice",
+		# 	"company": company,
+		# 	"supplier": supplier,
+		# 	"update_stock": 1,  # Update stock
+		# 	"posting_date": nowdate(),
+		# 	"items": [
+		# 		{
+		# 			"item_code": item_code,
+		# 			"qty": qty,
+		# 			"rate": rate,
+		# 			"location": "Test Location",  # Linking the correct warehouse
+		# 			"asset_location": "Test Location",  # Specifying asset location
+		# 			"expense_account":"_Test Comapny - _TC"
+		# 		}
+		# 	]
+		# })
+		# pi.insert()
+		# pi.submit()
+		# frappe.db.commit()
+	
+		asset_repair = frappe.get_doc({
+			"doctype": "Asset Repair",
+			"asset":target_asset,
+			"company": company,
+			"failure_date":"17-01-2025 14:49:20",
+			"completion_date":"17-01-2025 14:52:22",
+			"repair_status":"Pending",
+			
+
+		}).insert()
+		frappe.db.commit()
+	
+
+	# TC_FA_138
+	def test_completed_asset_repair_submit_on_complete_status_TC_FA_138(self):
+
+		company = "_Test Company"
+		item_code = "Test_asset_repair_item1"
+		asset_name = "Test_asset_maintainance"
+		# Ensure the company exists
+		if not frappe.db.exists("Company", company):
+			create_child_company()
+
+		# Create the item if it doesn't exist
+		if not frappe.db.exists("Item", item_code):
+			item_data = {
+				"doctype": "Item",
+				"item_code": item_code,
+				"item_name": item_code,
+				"is_stock_item": 0,
+				"is_fixed_asset": 1,  # Marking as fixed asset
+				"asset_naming_series": "ACC-ASS-.YYYY.-",
+				"asset_category": "Test_Category",
+				"item_group":"Raw Material",
+				"stock_uom":"Nos",
+
+			}
+
+			# Check if 'gst_hsn_code' exists in Item doctype
+			if frappe.db.has_column("Item", "gst_hsn_code"):
+				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
+			frappe.get_doc(item_data).insert()
+		
+		target_asset = frappe.get_doc({
+			"doctype": "Asset",
+			"company": company,
+			"item_code": item_code,
+			"asset_name": item_code,
+			"asset_category":"Test_Category",
+			"location": "Test Location",
+			"is_existing_asset":1,
+			"available_for_use_date":"02-04-2024",
+			"gross_purchase_amount":8000,
+			"total_asset":8000,
+			"asset_quantity":2,
+			"purchase_date":"01-04-2024",
+			"calculate_depreciation":0,
+			"opening_accumulated_depreciation":8000,
+			"opening_number_of_booked_depreciations":8,
+			"is_fully_depreciated":1,
+			"maintenance_required":1,
+			"finance_books":[{
+				"finance_book":"2024-2025",
+				"frequency_of_depreciation":1,
+				"depreciation_method":"Straight Line",
+				"depreciation_start_date":"01-06-2025",
+				"total_number_of_depreciations":12,
+				"total_number_of_booked_depreciations":7,
+				"value_after_depreciation":5000
+					}]
+		}).insert()
+		target_asset.submit()
+		frappe.db.commit()
+
+		company = "_Test Company"
+		supplier = "_Test Supplier"
+		qty, rate, warehouse = 1, 500, "_Test Warehouse - _TC"
+		required_by_date = nowdate()
+
+		# pi = frappe.get_doc({
+		# 	"doctype": "Purchase Invoice",
+		# 	"company": company,
+		# 	"supplier": supplier,
+		# 	"update_stock": 1,  # Update stock
+		# 	"posting_date": nowdate(),
+		# 	"items": [
+		# 		{
+		# 			"item_code": item_code,
+		# 			"qty": qty,
+		# 			"rate": rate,
+		# 			"location": "Test Location",  # Linking the correct warehouse
+		# 			"asset_location": "Test Location",  # Specifying asset location
+		# 			"expense_account":"_Test Comapny - _TC"
+		# 		}
+		# 	]
+		# })
+		# pi.insert()
+		# pi.submit()
+		# frappe.db.commit()
+	
+		asset_repair = frappe.get_doc({
+			"doctype": "Asset Repair",
+			"asset":target_asset,
+			"company": company,
+			"failure_date":"17-01-2025 14:49:20",
+			"completion_date":"17-01-2025 14:52:22",
+			"repair_status":"Completed",
+			
+
+		}).insert()
+		asset_repair.submit()
+		frappe.db.commit()
+	
+	# TC_FA_139
+	def test_service_item_asset_repair_submit_on_complete_status_TC_FA_139(self):
+		company = "_Test Company"
+		item_code = "Test_asset_nostock_repair_item1"
+		asset_name = "Test_asset_maintainance"
+
+		# Ensure the company exists
+		if not frappe.db.exists("Company", company):
+			create_child_company()
+
+		# Create the non-stock asset item if it doesn't exist
+		if not frappe.db.exists("Item", item_code):
+			item_data = {
+				"doctype": "Item",
+				"item_code": item_code,
+				"item_name": item_code,
+				"is_stock_item": 0,  # FIX: Ensuring it is a non-stock item
+				"is_fixed_asset": 1,  # Marking as fixed asset
+				"is_purchase_item": 1,  # Allow purchase of this asset
+				"asset_naming_series": "ACC-ASS-.YYYY.-",
+				"asset_category": "Test_Category",
+				"item_group": "Raw Material",
+				"stock_uom": "Nos",
+			}
+
+			# Check if 'gst_hsn_code' exists in Item doctype
+			if frappe.db.has_column("Item", "gst_hsn_code"):
+				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
+			frappe.get_doc(item_data).insert()
+		
+		# Create Asset (Non-Stock)
+		target_asset = frappe.get_doc({
+			"doctype": "Asset",
+			"company": company,
+			"item_code": item_code,
+			"asset_name": item_code,
+			"asset_category": "Test_Category",
+			"location": "Test Location",
+			"is_existing_asset": 1,
+			"available_for_use_date": "02-04-2024",
+			"gross_purchase_amount": 8000,
+			"total_asset": 8000,
+			"asset_quantity": 2,
+			"purchase_date": "01-04-2024",
+			"calculate_depreciation": 0,
+			"opening_accumulated_depreciation": 8000,
+			"opening_number_of_booked_depreciations": 8,
+			"is_fully_depreciated": 1,
+			"maintenance_required": 1,
+			"finance_books": [
+				{
+					"finance_book": "2024-2025",
+					"frequency_of_depreciation": 1,
+					"depreciation_method": "Straight Line",
+					"depreciation_start_date": "01-06-2025",
+					"total_number_of_depreciations": 12,
+					"total_number_of_booked_depreciations": 7,
+					"value_after_depreciation": 5000,
+				}
+			]
+		}).insert()
+		target_asset.submit()
+		frappe.db.commit()
+
+		# Create Purchase Invoice (for Non-Stock Asset)
+		supplier = "_Test Supplier"
+		qty, rate = 1, 500
+
+		pi = frappe.get_doc({
+			"doctype": "Purchase Invoice",
+			"company": company,
+			"supplier": supplier,
+			"update_stock": 0,  # FIX: No stock update for non-stock item
+			"posting_date": nowdate(),
+			"items": [
+				{
+					"item_code": item_code,
+					"qty": qty,
+					"rate": rate,
+					"location": "Test Location",  # Linking the correct warehouse
+					"asset_location": "Test Location",  # Specifying asset location
+					"expense_account": "_Test Account Cost for Goods Sold - _TC",
+				}
+			]
+		})
+		pi.insert()
+		pi.submit()
+		frappe.db.commit()
+
+		# Create Asset Repair
+		asset_repair = frappe.get_doc({
+			"doctype": "Asset Repair",
+			"asset": target_asset.name,  # Using asset name instead of object
+			"company": company,
+			"failure_date": "17-01-2025 14:49:20",
+			"completion_date": "17-01-2025 14:52:22",
+			"repair_status": "Completed",
+			"invoices": [
+				{
+					"purchase_invoice": pi.name,  # Using .name instead of object
+					"expense_account": "Service - _TC",
+					"repair_cost": 10000,
+				}
+			]
+		}).insert()
+		asset_repair.submit()
+		frappe.db.commit()
+
 	def test_update_status(self):
 		asset = create_asset(submit=1)
 		initial_status = asset.status

--- a/assets/assets/doctype/asset_repair/test_asset_repair.py
+++ b/assets/assets/doctype/asset_repair/test_asset_repair.py
@@ -197,27 +197,6 @@ class TestAssetRepair(unittest.TestCase):
 		supplier = "_Test Supplier"
 		qty, rate, warehouse = 1, 500, "_Test Warehouse - _TC"
 		required_by_date = nowdate()
-
-		# pi = frappe.get_doc({
-		# 	"doctype": "Purchase Invoice",
-		# 	"company": company,
-		# 	"supplier": supplier,
-		# 	"update_stock": 1,  # Update stock
-		# 	"posting_date": nowdate(),
-		# 	"items": [
-		# 		{
-		# 			"item_code": item_code,
-		# 			"qty": qty,
-		# 			"rate": rate,
-		# 			"location": "Test Location",  # Linking the correct warehouse
-		# 			"asset_location": "Test Location",  # Specifying asset location
-		# 			"expense_account":"_Test Comapny - _TC"
-		# 		}
-		# 	]
-		# })
-		# pi.insert()
-		# pi.submit()
-		# frappe.db.commit()
 	
 		asset_repair = frappe.get_doc({
 			"doctype": "Asset Repair",
@@ -297,27 +276,6 @@ class TestAssetRepair(unittest.TestCase):
 		supplier = "_Test Supplier"
 		qty, rate, warehouse = 1, 500, "_Test Warehouse - _TC"
 		required_by_date = nowdate()
-
-		# pi = frappe.get_doc({
-		# 	"doctype": "Purchase Invoice",
-		# 	"company": company,
-		# 	"supplier": supplier,
-		# 	"update_stock": 1,  # Update stock
-		# 	"posting_date": nowdate(),
-		# 	"items": [
-		# 		{
-		# 			"item_code": item_code,
-		# 			"qty": qty,
-		# 			"rate": rate,
-		# 			"location": "Test Location",  # Linking the correct warehouse
-		# 			"asset_location": "Test Location",  # Specifying asset location
-		# 			"expense_account":"_Test Comapny - _TC"
-		# 		}
-		# 	]
-		# })
-		# pi.insert()
-		# pi.submit()
-		# frappe.db.commit()
 	
 		asset_repair = frappe.get_doc({
 			"doctype": "Asset Repair",


### PR DESCRIPTION
Test cases on asset repair doctype 
creation of asset repair based on the Pending and completed status with PI 
TC_FA_101 , test_cancel_asset_and_manual_asset_depreciation_schedule_TC_FA_101  :
"Cannot amend depreciation figures other than manual method of depreciation
All JV's must be cancelled once schdeule gets cancelled and cannot link cancelled JV entries. Therefore, remove the cancelled JV link from Asset depreciation schedule"
TC_FA_137 , test_pending_asset_repair_submit_on_complete_status_TC_FA_137:
"Cannot submit asset repair in pending stage.
Asset repair must be completed and then we can submit.
Asset Status: Out of Order"

TC_FA_138 , test_completed_asset_repair_submit_on_complete_status_TC_FA_138:
"If repair status is completed, and the repair cost is 0, there will be no ledger impact.
Asset Status:Submitted"

TC_FA_139 , test_service_item_asset_repair_submit_on_complete_status_TC_FA_139:
Creating asset repair and purchase invoice, based on the service item we will be creating and linking to asset and asset repair

