### PR TITLE
test: test case for multiple group asset sales return_TC_FA_112

### DIFF
--- a/assets/assets/doctype/asset/test_asset.py
+++ b/assets/assets/doctype/asset/test_asset.py
@@ -6815,6 +6815,89 @@ class TestDepreciationBasics(AssetSetup):
 		for entry in je_gle_entries:
 			self.assertEqual(entry["debit"], expected_si_entries.get(entry["account"], {}).get("debit", 0))
 			self.assertEqual(entry["credit"], expected_si_entries.get(entry["account"], {}).get("credit", 0))
+
+	@if_app_installed("erpnext")
+	def test_multiple_group_asset_sales_return_single_invoice_TC_FA_112(self):
+		from erpnext.accounts.doctype.sales_invoice.sales_invoice import make_sales_return
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_company_or_supplier
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
+		get_details = get_company_or_supplier()
+		company = get_details.get("company")
+		frappe.db.set_value("Company", company, "depreciation_cost_center", "Main - TC-5")
+		customer = get_or_create_customer("_Test Customer")
+		supplier = get_details.get("supplier")
+		asset_category = get_asset_category()
+		location = get_location()
+
+		item_1 = make_test_item("test_asset_item_1")
+		item_1.is_stock_item = 0
+		item_1.is_fixed_asset = 1
+		item_1.is_grouped_asset = 1
+		item_1.asset_category = asset_category
+		item_1.save()
+
+		item_2 = make_test_item("test_asset_item_2")
+		item_2.is_stock_item = 0
+		item_2.is_fixed_asset = 1
+		item_2.is_grouped_asset = 1
+		item_2.asset_category = asset_category
+		item_2.save()
+
+		pr = create_purchase_receipt(item_1, company, supplier, item_2)
+
+		asset_1 = create_assets(company, location, pr, item_1.item_code)
+		asset_2 = create_assets(company, location, pr, item_2.item_code)
+
+		si = frappe.get_doc(
+			{
+				"doctype": "Sales Invoice",
+				"company": company,
+				"posting_date": frappe.utils.today(),
+				"customer": customer,
+				"items": [
+					{
+						"item_code": item_1.item_code,
+						"qty": 1,
+						"rate": 1000,
+						"asset": asset_1
+					},
+					{
+						"item_code": item_2.item_code,
+						"qty": 1,
+						"rate": 1000,
+						"asset": asset_2
+					}
+				],
+			}
+		)
+		si.insert()
+		si.submit()
+		self.assertEqual(si.docstatus, 1)
+
+		asset_1_status = frappe.get_doc("Asset", asset_1)
+		asset_2_status = frappe.get_doc("Asset", asset_2)
+
+		self.assertEqual(asset_1_status.status, "Sold")
+		self.assertEqual(asset_2_status.status, "Sold")
+
+		gl_entries_si = get_gl_entries("Sales Invoice", si.name)
+		self.assertGreater(len(gl_entries_si), 1)
+
+		sr = make_sales_return(si.name)
+		sr.insert()
+		sr.submit()
+
+		self.assertEqual(sr.docstatus, 1)
+		self.assertEqual(sr.status, "Return")
+
+		gl_entries_sr = get_gl_entries("Sales Invoice", sr.name)
+		self.assertGreater(len(gl_entries_sr), 1)
+
+		return_asset_status_1 = frappe.get_doc("Asset", asset_1)
+		return_asset_status_2 = frappe.get_doc("Asset", asset_2)
+
+		self.assertNotEqual(return_asset_status_1.status, "Sold")
+		self.assertNotEqual(return_asset_status_2.status, "Sold")
 	
 def get_gl_entries(doctype, docname):
 	gl_entry = frappe.qb.DocType("GL Entry")


### PR DESCRIPTION
TC_FA_112 - test_multiple_group_asset_sales_return_single_invoice_TC_FA_112

test case verifies the creates a sales invoice for multiple assets(group) and checks the GL Entries, after submitting the sales invoice checks the status of the asset it should be 'Sold', then creates a sales return against sales invoice saved and submitted sales return, checks the GL Entries against sales return. after sales return submission again checks the asset status it should be not 'Sold'