### PR TITLE
test: test case for asset repair with multiple pi_TC_FA_114

### DIFF
--- a/assets/assets/doctype/asset/test_asset.py
+++ b/assets/assets/doctype/asset/test_asset.py
@@ -6815,6 +6815,46 @@ class TestDepreciationBasics(AssetSetup):
 		for entry in je_gle_entries:
 			self.assertEqual(entry["debit"], expected_si_entries.get(entry["account"], {}).get("debit", 0))
 			self.assertEqual(entry["credit"], expected_si_entries.get(entry["account"], {}).get("credit", 0))
+
+	@if_app_installed("erpnext")
+	def test_asset_repair_with_multiple_pi_TC_FA_114(self):
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import get_company_or_supplier
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import make_test_item
+		get_details = get_company_or_supplier()
+		company = get_details.get("company")
+		supplier = get_details.get("supplier")
+		frappe.db.set_value("Company", company, "depreciation_cost_center", "Main - TC-5")
+		asset_category = get_asset_category()
+		location = get_location()
+
+		item_1 = make_test_item("test_asset_item_for_repair_1")
+		item_1.is_stock_item = 0
+		item_1.is_fixed_asset = 1
+		item_1.asset_category = asset_category
+		item_1.save()
+
+		pr = create_purchase_receipt(item_1, company, supplier)
+
+		asset = create_assets(company, location, pr, item_1.item_code)
+
+		pi_1 = create_pi(company, supplier)
+		pi_1.insert()
+		pi_1.submit()
+		self.assertEqual(pi_1.docstatus, 1)
+
+		pi_gle_entries_1 = frappe.get_all("GL Entry", filters={"voucher_no": pi_1.name}, fields=["account", "debit", "credit"])
+		expected_pi_entries = {
+			"Cost of Goods Sold - TC-5": {"debit": 1000, "credit": 0},
+			"Creditors - TC-5": {"debit": 0, "credit": 1000},
+		}
+		for entry in pi_gle_entries_1:
+			self.assertEqual(entry["debit"], expected_pi_entries.get(entry["account"], {}).get("debit", 0))
+			self.assertEqual(entry["credit"], expected_pi_entries.get(entry["account"], {}).get("credit", 0))
+
+		pi_2 = create_pi(company, supplier)
+		pi_2.insert()
+		pi_2.submit()
+		self.assertEqual(pi_2.docstatus, 1)
 	
 def get_gl_entries(doctype, docname):
 	gl_entry = frappe.qb.DocType("GL Entry")


### PR DESCRIPTION
TC-FA-114 - test_asset_repair_with_multiple_pi_TC_FA_114

This test case verifies that creation of Asset Repair from Asset doctype by adding the multiple purchase invoices in the asset repair invoices table. also verifies the GL Entries for the Purchase Invoices