### PR TITLE
Fix: asset module issues edit restrictions, repair cost miscalculations, and invalid landed cost validations

### DIFF
--- a/assets/assets/customizations/stock/landed_cost_voucher/doc_events.py
+++ b/assets/assets/customizations/stock/landed_cost_voucher/doc_events.py
@@ -9,29 +9,39 @@ def update_landed_cost(self):
             validate_asset_qty_and_status(self, d.receipt_document_type, doc)
 
 def validate_asset_qty_and_status(self, receipt_document_type, receipt_document):
-    for item in self.get("items"):
-        if item.is_fixed_asset:
-            receipt_document_type = (
-                "purchase_invoice"
-                if item.receipt_document_type == "Purchase Invoice"
-                else "purchase_receipt"
-            )
-            docs = frappe.db.get_all(
-                "Asset",
-                filters={receipt_document_type: item.receipt_document, "item_code": item.item_code},
-                fields=["name", "docstatus"],
-            )
-            if not docs or len(docs) < item.qty:
-                frappe.throw(
-                    _(
-                        "There are only {0} asset created or linked to {1}. Please create or link {2} Assets with respective document."
-                    ).format(len(docs), item.receipt_document, item.qty)
-                )
-            if docs:
-                for d in docs:
-                    if d.docstatus == 1:
-                        frappe.throw(
-                            _(
-                                "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
-                            ).format(item.receipt_document_type, item.receipt_document, item.item_code)
-                        )
+		for item in self.get("items"):
+			if item.is_fixed_asset:
+				receipt_document_type = (
+					"purchase_invoice"
+					if item.receipt_document_type == "Purchase Invoice"
+					else "purchase_receipt"
+				)
+				docs = frappe.db.get_all(
+					"Asset",
+					filters={
+						receipt_document_type: item.receipt_document,
+						"item_code": item.item_code,
+						"docstatus": ["!=", 2],
+					},
+					fields=["name", "docstatus", "asset_quantity"],
+				)
+
+				total_asset_qty = sum((cint(d.asset_quantity)) for d in docs)
+
+				if not docs or total_asset_qty < item.qty:
+					frappe.throw(
+						_(
+							"For item <b>{0}</b>, only <b>{1}</b> asset have been created or linked to <b>{2}</b>. "
+							"Please create or link <b>{3}</b> more asset with the respective document."
+						).format(
+							item.item_code, total_asset_qty, item.receipt_document, item.qty - total_asset_qty
+						)
+					)
+				if docs:
+					for d in docs:
+						if d.docstatus == 1:
+							frappe.throw(
+								_(
+									"{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
+								).format(item.receipt_document_type, item.receipt_document, item.item_code)
+							)

--- a/assets/assets/doctype/asset/asset.js
+++ b/assets/assets/doctype/asset/asset.js
@@ -691,10 +691,6 @@ frappe.ui.form.on("Asset", {
 					} else {
 						frm.set_value("purchase_invoice_item", data.purchase_invoice_item);
 					}
-
-					let is_editable = !data.is_multiple_items; // if multiple items, then fields should be read-only
-					frm.set_df_property("gross_purchase_amount", "read_only", is_editable);
-					frm.set_df_property("asset_quantity", "read_only", is_editable);
 				}
 			},
 		});

--- a/assets/assets/doctype/asset/asset.json
+++ b/assets/assets/doctype/asset/asset.json
@@ -89,6 +89,7 @@
    "options": "ACC-ASS-.YYYY.-"
   },
   {
+   "allow_on_submit": 1,
    "depends_on": "item_code",
    "fetch_from": "item_code.item_name",
    "fetch_if_empty": 1,
@@ -516,6 +517,7 @@
    "fieldname": "total_asset_cost",
    "fieldtype": "Currency",
    "label": "Total Asset Cost",
+   "no_copy": 1,
    "options": "Company:company:default_currency",
    "read_only": 1
   },
@@ -524,6 +526,7 @@
    "fieldname": "additional_asset_cost",
    "fieldtype": "Currency",
    "label": "Additional Asset Cost",
+   "no_copy": 1,
    "options": "Company:company:default_currency",
    "read_only": 1
   },
@@ -613,7 +616,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2024-11-21 14:59:07.456081",
+ "modified": "2025-04-24 15:31:47.373274",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",
@@ -651,6 +654,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_name_in_global_search": 1,
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/assets/assets/doctype/asset/asset.py
+++ b/assets/assets/doctype/asset/asset.py
@@ -43,6 +43,8 @@ from assets.assets.doctype.asset_depreciation_schedule.asset_depreciation_schedu
 
 class Asset(AccountsController):
 	# begin: auto-generated types
+	# ruff: noqa
+
 	# This code is auto-generated. Do not modify anything in this block.
 
 	from typing import TYPE_CHECKING
@@ -120,6 +122,7 @@ class Asset(AccountsController):
 		total_asset_cost: DF.Currency
 		total_number_of_depreciations: DF.Int
 		value_after_depreciation: DF.Currency
+	# ruff: noqa
 	# end: auto-generated types
 
 	def validate(self):
@@ -1211,7 +1214,6 @@ def get_values_from_purchase_doc(purchase_doc_name, item_code, doctype):
 		frappe.throw(_(f"Selected {doctype} does not contain the Item Code {item_code}"))
 
 	first_item = matching_items[0]
-	is_multiple_items = len(matching_items) > 1
 
 	return {
 		"company": purchase_doc.company,
@@ -1220,7 +1222,6 @@ def get_values_from_purchase_doc(purchase_doc_name, item_code, doctype):
 		"asset_quantity": first_item.qty,
 		"cost_center": first_item.cost_center or purchase_doc.get("cost_center"),
 		"asset_location": first_item.get("asset_location"),
-		"is_multiple_items": is_multiple_items,
 		"purchase_receipt_item": first_item.name if doctype == "Purchase Receipt" else None,
 		"purchase_invoice_item": first_item.name if doctype == "Purchase Invoice" else None,
 	}

--- a/assets/assets/doctype/asset/depreciation.py
+++ b/assets/assets/doctype/asset/depreciation.py
@@ -858,19 +858,16 @@ def get_gl_entries_on_asset_disposal(
 
 
 def get_asset_details(asset, finance_book=None):
-	fixed_asset_account, accumulated_depr_account, _ = get_depreciation_accounts(
-		asset.asset_category, asset.company
+	value_after_depreciation = asset.get_value_after_depreciation(finance_book)
+	accumulated_depr_amount = flt(asset.gross_purchase_amount) - flt(value_after_depreciation)
+
+	fixed_asset_account, accumulated_depr_account, _ = get_asset_accounts(
+		asset.asset_category, asset.company, accumulated_depr_amount
 	)
 	disposal_account, depreciation_cost_center = get_disposal_account_and_cost_center(
 		asset.company
 	)
 	depreciation_cost_center = asset.cost_center or depreciation_cost_center
-
-	value_after_depreciation = asset.get_value_after_depreciation(finance_book)
-
-	accumulated_depr_amount = flt(asset.gross_purchase_amount) - flt(
-		value_after_depreciation
-	)
 
 	return (
 		fixed_asset_account,
@@ -881,6 +878,47 @@ def get_asset_details(asset, finance_book=None):
 		disposal_account,
 		value_after_depreciation,
 	)
+
+def get_asset_accounts(asset_category, company, accumulated_depr_amount):
+	fixed_asset_account = accumulated_depreciation_account = depreciation_expense_account = None
+
+	accounts = frappe.db.get_value(
+		"Asset Category Account",
+		filters={"parent": asset_category, "company_name": company},
+		fieldname=[
+			"fixed_asset_account",
+			"accumulated_depreciation_account",
+			"depreciation_expense_account",
+		],
+		as_dict=1,
+	)
+
+	if accounts:
+		fixed_asset_account = accounts.fixed_asset_account
+		accumulated_depreciation_account = accounts.accumulated_depreciation_account
+		depreciation_expense_account = accounts.depreciation_expense_account
+
+	if not fixed_asset_account:
+		frappe.throw(_("Please set Fixed Asset Account in Asset Category {0}").format(asset_category))
+
+	if accumulated_depr_amount:
+		accounts = frappe.get_cached_value(
+			"Company", company, ["accumulated_depreciation_account", "depreciation_expense_account"]
+		)
+
+		if not accumulated_depreciation_account:
+			accumulated_depreciation_account = accounts[0]
+		if not depreciation_expense_account:
+			depreciation_expense_account = accounts[1]
+
+		if not accumulated_depreciation_account or not depreciation_expense_account:
+			frappe.throw(
+				_("Please set Depreciation related Accounts in Asset Category {0} or Company {1}").format(
+					asset_category, company
+				)
+			)
+
+	return fixed_asset_account, accumulated_depreciation_account, depreciation_expense_account
 
 
 def get_profit_gl_entries(

--- a/assets/assets/doctype/asset_movement/asset_movement.py
+++ b/assets/assets/doctype/asset_movement/asset_movement.py
@@ -211,6 +211,9 @@ class AssetMovement(Document):
 				args,
 				as_dict=True,
 			)
+
+			self.validate_movement_cancellation(d, latest_movement_entry)
+
 			if latest_movement_entry:
 				current_location = latest_movement_entry[0]["target_location"]
 				current_employee = latest_movement_entry[0]["to_employee"]
@@ -273,6 +276,15 @@ class AssetMovement(Document):
 						get_link_to_form("Employee", current_employee)
 					),
 				)
+
+	def validate_movement_cancellation(self, row, latest_movement_entry):
+		asset_doc = frappe.get_doc("Asset", row.asset)
+		if not latest_movement_entry and asset_doc.docstatus == 1:
+			frappe.throw(
+				_(
+					"Asset {0} has only one movement record. Please create another movement before deleting this one to maintain asset tracking."
+				).format(row.asset)
+			)
 
 	def on_cancel_reverse_depreciation_schedule(self):
 		transaction_date = getdate(self.transaction_date)

--- a/assets/assets/doctype/asset_movement/test_asset_movement.py
+++ b/assets/assets/doctype/asset_movement/test_asset_movement.py
@@ -3183,6 +3183,45 @@ class TestAssetMovement(unittest.TestCase):
 			frappe.db.get_value("Asset", asset.name, "location"), "Test Location"
 		)
 
+	def test_last_movement_cancellation_validation(self):
+		pr = make_purchase_receipt(item_code="Macbook Pro", qty=1, rate=100000.0, location="Test Location")
+
+		asset_name = frappe.db.get_value("Asset", {"purchase_receipt": pr.name}, "name")
+		asset = frappe.get_doc("Asset", asset_name)
+		asset.calculate_depreciation = 1
+		asset.available_for_use_date = "2020-06-06"
+		asset.purchase_date = "2020-06-06"
+		asset.append(
+			"finance_books",
+			{
+				"expected_value_after_useful_life": 10000,
+				"next_depreciation_date": "2020-12-31",
+				"depreciation_method": "Straight Line",
+				"total_number_of_depreciations": 3,
+				"frequency_of_depreciation": 10,
+			},
+		)
+		if asset.docstatus == 0:
+			asset.submit()
+
+		AssetMovement = frappe.qb.DocType("Asset Movement")
+		AssetMovementItem = frappe.qb.DocType("Asset Movement Item")
+
+		asset_movement = (
+			frappe.qb.from_(AssetMovement)
+			.join(AssetMovementItem)
+			.on(AssetMovementItem.parent == AssetMovement.name)
+			.select(AssetMovement.name)
+			.where(
+				(AssetMovementItem.asset == asset.name)
+				& (AssetMovement.company == asset.company)
+				& (AssetMovement.docstatus == 1)
+			)
+		).run(as_dict=True)
+
+		asset_movement_doc = frappe.get_doc("Asset Movement", asset_movement[0].name)
+		self.assertRaises(frappe.ValidationError, asset_movement_doc.cancel)
+
 	def test_depriciation_schedule_entry(self):
 		pr = make_purchase_receipt(
 			item_code="Macbook Pro",

--- a/assets/assets/doctype/asset_repair/asset_repair.py
+++ b/assets/assets/doctype/asset_repair/asset_repair.py
@@ -148,9 +148,12 @@ class AssetRepair(AccountsController):
 
 			self.increase_asset_value()
 
+			total_repair_cost = self.get_total_value_of_stock_consumed()
+
 			if self.capitalize_repair_cost:
-				self.asset_doc.total_asset_cost += self.repair_cost
-				self.asset_doc.additional_asset_cost += self.repair_cost
+				total_repair_cost += self.repair_cost
+			self.asset_doc.total_asset_cost += total_repair_cost
+			self.asset_doc.additional_asset_cost += total_repair_cost
 
 			if self.get("stock_consumption"):
 				self.check_for_stock_items_and_warehouse()
@@ -189,9 +192,11 @@ class AssetRepair(AccountsController):
 
 			self.decrease_asset_value()
 
+			total_repair_cost = self.get_total_value_of_stock_consumed()
 			if self.capitalize_repair_cost:
-				self.asset_doc.total_asset_cost -= self.repair_cost
-				self.asset_doc.additional_asset_cost -= self.repair_cost
+				total_repair_cost += self.repair_cost
+			self.asset_doc.total_asset_cost -= total_repair_cost
+			self.asset_doc.additional_asset_cost -= total_repair_cost
 
 			if self.get("capitalize_repair_cost"):
 				self.ignore_linked_doctypes = ("GL Entry", "Stock Ledger Entry")


### PR DESCRIPTION
### Title: Fix: Asset Management Bugs Related to Editability, Cost Updates, and Validation
### Description
- asset commits are added from standard erpnext-version-15 till 6th may asset commits are added from standard erpnext-version-15 till 6th may
- Several issues were identified in the Asset module that restricted editability, caused inconsistencies in cost calculations after repairs, and triggered incorrect validations during landed cost allocations. These impacted user flexibility and accounting accuracy in asset-related workflows.

### Root Cause
- The Asset Name field was missing the allow_on_submit flag, preventing post-submission edits.

- Client-side scripting enforced read-only status for key fields such as asset_quantity and gross_purchase_amount, even when legitimate updates were needed.

- Asset Repair logic did not update additional_cost or total_asset_cost based on the value of consumed stock. Additionally, these cost fields were incorrectly carried over when duplicating repair entries.

- The Landed Cost Voucher validation logic used the number of asset line items instead of the actual asset_quantity, resulting in incorrect quantity validation.

### Steps to Reproduce
- Submit an Asset document, then attempt to edit the Asset Name — field is locked.

 - Try to modify Asset Quantity or Gross Purchase Amount in an existing asset — fields remain read-only.

- Perform an asset repair that consumes stock — total cost remains unchanged.

 - Create a Landed Cost Voucher with multiple quantities for the same asset — validation fails due to mismatch.

### Actual/Observed Result
- Asset Name, Quantity, and Gross Purchase Amount fields were not editable after submission.

- Repairs failed to update asset costs accurately.

- Landed Cost Vouchers triggered false validation errors.

### Expected Result
- Editable fields (like Asset Name) should be allowed post-submission where business logic permits.

- Asset costs should reflect actual expenses, including repair-related stock consumption.

- Landed Cost Voucher validations should respect the correct asset quantity, not row counts.

### Fix Summary
- Enabled post-submission edits for the Asset Name by setting allow_on_submit = 1.

- Removed client-side restrictions on asset_quantity and gross_purchase_amount.

- Accurately add consumed stock value to additional_cost and total_asset_cost.

- Prevent these fields from being copied during repair duplication.

- Corrected Landed Cost Voucher validation to use asset_quantity instead of row count.

### Affected Module
- Assets

- Test Cases Covered
N/A

- Linked Issues
N/A