### PR TITLE
fix: Finance Book has been created and assigned in the Asset Record

### DIFF
--- a/assets/assets/doctype/asset/test_asset.py
+++ b/assets/assets/doctype/asset/test_asset.py
@@ -2612,6 +2612,14 @@ class TestAsset(AssetSetup):
 		self.assertRaises(frappe.ValidationError, asset.save)
 
 	def test_purchase_asset(self):
+		finance_book_name = "Test Finance Book 1"
+
+		if not frappe.db.exists("Finance Book", finance_book_name):
+			frappe.get_doc({
+				"doctype": "Finance Book",
+				"finance_book_name": finance_book_name
+			}).insert()
+
 		pr = make_purchase_receipt(
 			item_code="Macbook Pro", qty=1, rate=100000.0, location="Test Location"
 		)
@@ -2630,6 +2638,7 @@ class TestAsset(AssetSetup):
 			{
 				"expected_value_after_useful_life": 10000,
 				"depreciation_method": "Straight Line",
+				"finance_book" : finance_book_name,
 				"total_number_of_depreciations": 3,
 				"frequency_of_depreciation": 10,
 				"depreciation_start_date": month_end_date,
@@ -2663,6 +2672,14 @@ class TestAsset(AssetSetup):
 		self.assertEqual(asset.docstatus, 2)
 
 	def test_purchase_of_grouped_asset(self):
+		finance_book_name = "Test Finance Book 1"
+
+		if not frappe.db.exists("Finance Book", finance_book_name):
+			frappe.get_doc({
+				"doctype": "Finance Book",
+				"finance_book_name": finance_book_name
+			}).insert()
+
 		create_fixed_asset_item("Rack", is_grouped_asset=1)
 		pr = make_purchase_receipt(
 			item_code="Rack", qty=3, rate=100000.0, location="Test Location"
@@ -2682,6 +2699,7 @@ class TestAsset(AssetSetup):
 			"finance_books",
 			{
 				"expected_value_after_useful_life": 10000,
+				"finance_book" : finance_book_name,
 				"depreciation_method": "Straight Line",
 				"total_number_of_depreciations": 3,
 				"frequency_of_depreciation": 10,
@@ -2895,6 +2913,13 @@ class TestAsset(AssetSetup):
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import (
 			create_sales_invoice,
 		)
+		finance_book_name = "Test Finance Book 1"
+
+		if not frappe.db.exists("Finance Book", finance_book_name):
+			frappe.get_doc({
+				"doctype": "Finance Book",
+				"finance_book_name": finance_book_name
+			}).insert()
 
 		asset = create_asset(
 			calculate_depreciation=1,
@@ -2904,6 +2929,7 @@ class TestAsset(AssetSetup):
 			total_number_of_depreciations=5,
 			opening_number_of_booked_depreciations=2,
 			frequency_of_depreciation=12,
+			finance_book = finance_book_name,
 			depreciation_start_date="2023-03-31",
 			opening_accumulated_depreciation=24000,
 			gross_purchase_amount=60000,
@@ -2971,6 +2997,15 @@ class TestAsset(AssetSetup):
 		self.assertSequenceEqual(gle, expected_gle)
 
 	def test_asset_with_maintenance_required_status_after_sale(self):
+
+		finance_book_name = "Test Finance Book 1"
+
+		if not frappe.db.exists("Finance Book", finance_book_name):
+			frappe.get_doc({
+				"doctype": "Finance Book",
+				"finance_book_name": finance_book_name
+			}).insert()
+
 		asset = create_asset(
 			calculate_depreciation=1,
 			available_for_use_date="2020-06-06",
@@ -2978,6 +3013,7 @@ class TestAsset(AssetSetup):
 			expected_value_after_useful_life=10000,
 			total_number_of_depreciations=3,
 			frequency_of_depreciation=10,
+			finance_book = finance_book_name,
 			maintenance_required=1,
 			depreciation_start_date="2020-12-31",
 			submit=1,
@@ -6090,6 +6126,7 @@ class TestDepreciationMethods(AssetSetup):
 		self.assertEqual(schedules, expected_schedules)
 
 	def test_schedule_for_double_declining_method_for_existing_asset(self):
+		
 		asset = create_asset(
 			calculate_depreciation=1,
 			available_for_use_date="2030-01-01",


### PR DESCRIPTION
**Title** : Finance Book Field Missing While Creating Asset

📝 **Description**:
On creation of an Asset, the system was expecting the Finance Book field to be mandatory. This caused validation issues when the field wasn't explicitly provided.

To resolve this, we created a Finance Book and assigned it to the respective Asset, ensuring that asset creation flows smoothly and adheres to accounting structure requirements.

✅ **Test** **Summary**
Test cases were written to validate:
Asset creation with assigned Finance Book.
Behavior of asset lifecycle including maintenance and sale.
Proper General Ledger (GL) entries during asset sale.
Handling of grouped asset purchases.
All scenarios confirm that the Finance Book assignment resolves prior errors and maintains expected accounting behavior.

🔍 **Scenarios Covered**
 Mandatory field validation for Finance Book
 Asset creation with required accounting configurations
 Asset sale and GL entry validation
 Grouped asset handling

🧪 **Technology**
Frappe Framework – utilizing Frappe's DocType validation and accounting system.

🧪 **Test Case IDs**
test_asset_with_maintenance_required_status_after_sale
test_gle_made_by_asset_sale_for_existing_asset
test_purchase_asset
test_purchase_of_grouped_asset

🔗 Linked Feature/Bug
https://github.com/8848digital/Assets/issues/241