### PR TITLE
Added validation for project attribute in 'make_item_gl_entries' method

### DIFF
--- a/assets/assets/customizations/accounts/purchase_invoice/override.py
+++ b/assets/assets/customizations/accounts/purchase_invoice/override.py
@@ -210,9 +210,9 @@ def make_item_gl_entries(self, gl_entries):
 		if provisional_accounting_for_non_stock_items:
 			self.get_provisional_accounts()
 
-		for item in self.get("items"):
-			if not frappe.db.has_column(self.doctype, "project"):
+		if not frappe.db.has_column(self.doctype, "project"):
 				self.project = ""
+		for item in self.get("items"):
 			if not frappe.db.has_column("Item", "project"):
 				item.project = ""
 			if flt(item.base_net_amount):

--- a/assets/assets/customizations/accounts/purchase_invoice/override.py
+++ b/assets/assets/customizations/accounts/purchase_invoice/override.py
@@ -211,6 +211,10 @@ def make_item_gl_entries(self, gl_entries):
 			self.get_provisional_accounts()
 
 		for item in self.get("items"):
+			if not frappe.db.has_column(self.doctype, "project"):
+				self.project = ""
+			if not frappe.db.has_column("Item", "project"):
+				item.project = ""
 			if flt(item.base_net_amount):
 				account_currency = get_account_currency(item.expense_account)
 				if item.item_code:


### PR DESCRIPTION
A validation has been put for projects attribute so that the method doesn't fail even if the projects app isn't installed.

Checks if the project column exists in the current document's doctype. If not, sets self.project = "".

Iterates over items and ensures that each Item does not attempt to reference a missing project column by setting item.project = "" if the column doesn't exist in the Item doctype.