### PR TITLE
fix: NameError: name 'cint' is not defined. Did you mean: 'int'?

### DIFF
--- a/assets/assets/customizations/stock/landed_cost_voucher/doc_events.py
+++ b/assets/assets/customizations/stock/landed_cost_voucher/doc_events.py
@@ -1,5 +1,7 @@
 import frappe
 from frappe import _
+from frappe.utils import cint
+
 
 def update_landed_cost(self):
     for d in self.get("purchase_receipts"):


### PR DESCRIPTION
Bug Description
When running a test for the Landed Cost Voucher (LCV) feature involving a Purchase Invoice for a fixed asset item (test_lcv_with_purchase_invoice_for_fixed_asset_item_TC_ACC_113), the test fails during submission with a NameError.

Root Cause
The function cint is used in the validate_asset_qty_and_status function, but it has not been imported or defined. Python raises a NameError because it doesn't recognize cint.

Expected Result
The LCV submission should process successfully, validating asset quantities and statuses without errors, as part of the automated test.

Actual Result
The test fails during the submission of the LCV with the following error:
NameError: name 'cint' is not defined. Did you mean: 'int'?

Fix Summary
Add the appropriate import statement for cint at the top of the file (doc_events.py). In Frappe, cint is a utility function typically imported as:
from frappe.utils import cint

Affected Module
assets.customizations.stock.landed_cost_voucher
Test Case resolved:
1.TC_ACC_113

Issue Id:
Fix https://github.com/8848digital/erpnext/issues/2445