### PR TITLE
fix: frappe.exceptions.LinkValidationError: Could not find Asset Cate…

### DIFF
--- a/assets/assets/doctype/asset_movement/test_asset_movement.py
+++ b/assets/assets/doctype/asset_movement/test_asset_movement.py
@@ -2350,6 +2350,13 @@ class TestAssetMovement(unittest.TestCase):
 				"company": company
 			}).insert()
 
+		if not frappe.db.exists("Asset Category", "Test_Category"):
+			frappe.get_doc({
+				"doctype": "Asset Category",
+				"asset_category_name": "Test_Category",
+				"accounts": [{"company_name":company, "fixed_asset_account": "Capital Equipments - _TC"}]
+			}).insert()
+
 		# Create item if it doesn't exist
 		if not frappe.db.exists("Item", item_code):
 			frappe.get_doc({


### PR DESCRIPTION
### Title:
Fix: LinkValidationError when assigning non-existent Asset Category

### Bug Description
The system throws a LinkValidationError when trying to create or reference an asset with a non-existent Asset Category, such as "Test_Category".

### Root Cause
The test or process referenced a hardcoded or dynamically generated Asset Category ("Test_Category") without ensuring it existed in the system.

Frappe automatically validates links to ensure referenced doctypes exist, and this check failed.

Steps to Reproduce:
Trigger any test or script that references "Test_Category" as an Asset Category.

Ensure that this category does not exist in the system.

Observe that Frappe throws:

frappe.exceptions.LinkValidationError: Could not find Asset Category: Test_Category

Actual/Observed Result:
Code crashes with LinkValidationError.

Expected Result:
Either the category should be pre-created during setup or gracefully handled with a clear message.

### Fix Summary
Added creation of Asset Category: Test_Category in test setup to ensure referential integrity.

Added validation to check for the existence of the Asset Category before using it in logic.

### Affected Module
Assets

### Test Cases Covered
None

### Linked Issue
Fixes #254

### PR Reference
None
