### PR TITLE
fix : Prevent AttributeError when accessing project in AssetsPurchaseInvoice if projects app is not installed

### DIFF
--- a/assets/assets/customizations/accounts/purchase_invoice/override.py
+++ b/assets/assets/customizations/accounts/purchase_invoice/override.py
@@ -332,7 +332,7 @@ def make_item_gl_entries(self, gl_entries):
 									"account": supplier_warehouse_account,
 									"against": item.expense_account,
 									"cost_center": item.cost_center,
-									"project": item.project or self.project,
+									"project": item.project or self.project if "projects" in frappe.get_installed_apps() else "",
 									"remarks": self.get("remarks") or _("Accounting Entry for Stock"),
 									"credit": flt(item.rm_supp_cost),
 								},
@@ -361,7 +361,7 @@ def make_item_gl_entries(self, gl_entries):
 									"against": self.supplier,
 									"debit": amount,
 									"cost_center": item.cost_center,
-									"project": item.project or self.project,
+									"project": item.project or self.project if "projects" in frappe.get_installed_apps() else ""
 								},
 								account_currency,
 								item=item,


### PR DESCRIPTION
### Title:
Fix: Prevent AttributeError when accessing project in AssetsPurchaseInvoice if projects app is not installed

### Bug Description
An error occurred when creating assets via Purchase Invoices due to the assumption that the project field is always available on AssetsPurchaseInvoice.

### Root Cause
The code accessed self.project directly, but the project field is only available when the projects app is installed.

This led to the following exception when the projects module was not present:
AttributeError: 'AssetsPurchaseInvoice' object has no attribute 'project'
Steps to Reproduce:
Use an instance without the projects app installed.

Try to submit a Purchase Invoice that triggers asset creation.

System throws an AttributeError when trying to read self.project.

Actual/Observed Result:
Asset creation fails with AttributeError.

Expected Result:
Asset creation proceeds, with or without the projects app installed.

### Fix Summary
Replaced:

"project": item.project or self.project
with:
"project": item.project or self.project if "projects" in frappe.get_installed_apps() else ""
This ensures project is accessed only if the projects app is installed, preventing the AttributeError.

### Affected Module
Assets

Asset creation via Purchase Invoice

### Test Cases Covered
None

### Linked Issue
Fixes #252

### PR Reference
None
