### PR TITLE
fix: Added missing finance_book field to Asset creation

### DIFF
--- a/assets/assets/doctype/asset_value_adjustment/test_asset_value_adjustment.py
+++ b/assets/assets/doctype/asset_value_adjustment/test_asset_value_adjustment.py
@@ -270,6 +270,11 @@ class TestAssetValueAdjustment(unittest.TestCase):
 		self.assertEqual(schedules, expected_schedules)
 
 	def test_difference_amount(self):
+		finance_book = frappe.get_doc({
+			"doctype": "Finance Book",
+			"finance_book_name": "_Test Book"
+		}).insert(ignore_if_duplicate=True, ignore_permissions=True)
+
 		pr = make_purchase_receipt(item_code="Macbook Pro", qty=1, rate=120000.0, location="Test Location")
 
 		asset_name = frappe.db.get_value("Asset", {"purchase_receipt": pr.name}, "name")
@@ -281,6 +286,7 @@ class TestAssetValueAdjustment(unittest.TestCase):
 		asset_doc.append(
 			"finance_books",
 			{
+				"finance_book": finance_book.name,
 				"expected_value_after_useful_life": 200,
 				"depreciation_method": "Straight Line",
 				"total_number_of_depreciations": 12,


### PR DESCRIPTION
### Title:
Fix: Added missing finance_book field to Asset

### Bug Description
Test case for Asset creation was failing due to missing mandatory field finance_book. This caused the test to raise a MandatoryError, preventing successful execution and asset document creation.

### Root Cause
The Asset doctype includes a mandatory child table finance_books where the finance_book field is required.
The test setup attempted to create an Asset without assigning any finance_book, resulting in the following error:
frappe.exceptions.MandatoryError: [Asset, ACC-ASS_12xxx]: finance_book
Steps to Reproduce:
Run the test that attempts to insert an Asset without appending finance_books.

Error is raised due to missing finance_book in the child table.

Actual/Observed Result:
Test fails with MandatoryError.

Expected Result:
Asset should be created successfully when required fields, including finance_book, are provided.

### Fix Summary
Created a test Finance Book with name _Test Book
Appended it to the Asset’s finance_books child table with necessary fields

### Affected Module
Assets

Asset Test Cases

Test Cases Covered
None

### Linked Issue
Fixes https://github.com/8848digital/Assets/issues/253

### PR Reference
None