### PR TITLE
chore: asset_commits_till_3rd_june

### DIFF
--- a/assets/assets/doctype/asset/asset.json
+++ b/assets/assets/doctype/asset/asset.json
@@ -159,6 +159,7 @@
   {
    "allow_on_submit": 1,
    "fetch_from": "item_code.image",
+   "fetch_if_empty": 1,
    "fieldname": "image",
    "fieldtype": "Attach Image",
    "hidden": 1,
@@ -616,7 +617,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2025-04-24 15:31:47.373274",
+ "modified": "2025-05-20 00:44:06.229177",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/assets/assets/doctype/asset/asset.py
+++ b/assets/assets/doctype/asset/asset.py
@@ -43,8 +43,6 @@ from assets.assets.doctype.asset_depreciation_schedule.asset_depreciation_schedu
 
 class Asset(AccountsController):
 	# begin: auto-generated types
-	# ruff: noqa
-
 	# This code is auto-generated. Do not modify anything in this block.
 
 	from typing import TYPE_CHECKING
@@ -122,10 +120,10 @@ class Asset(AccountsController):
 		total_asset_cost: DF.Currency
 		total_number_of_depreciations: DF.Int
 		value_after_depreciation: DF.Currency
-	# ruff: noqa
 	# end: auto-generated types
 
 	def validate(self):
+		self.validate_category()
 		self.validate_precision()
 		self.set_purchase_doc_row_item()
 		self.validate_asset_values()
@@ -370,6 +368,17 @@ class Asset(AccountsController):
 					),
 					title=_("Missing Finance Book"),
 				)
+
+	def validate_category(self):
+		non_depreciable_category = frappe.db.get_value(
+			"Asset Category", self.asset_category, "non_depreciable_category"
+		)
+		if self.calculate_depreciation and non_depreciable_category:
+			frappe.throw(
+				_(
+					"This asset category is marked as non-depreciable. Please disable depreciation calculation or choose a different category."
+				)
+			)
 
 	def validate_precision(self):
 		if self.gross_purchase_amount:
@@ -883,7 +892,7 @@ class Asset(AccountsController):
 
 			if args.get("rate_of_depreciation") and not flt(args.get("expected_value_after_useful_life")):
 				return args.get("rate_of_depreciation")
-				
+
 				value = flt(args.get("expected_value_after_useful_life")) / flt(
 					args.get("value_after_depreciation")
 				)

--- a/assets/assets/doctype/asset/depreciation.py
+++ b/assets/assets/doctype/asset/depreciation.py
@@ -2,14 +2,7 @@
 # For license information, please see license.txt
 
 
-import erpnext
 import frappe
-from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
-	get_checks_for_pl_and_bs_accounts,
-)
-from erpnext.accounts.doctype.journal_entry.journal_entry import (
-	make_reverse_journal_entry,
-)
 from frappe import _
 from frappe.query_builder import Order
 from frappe.query_builder.functions import Max, Min
@@ -26,6 +19,11 @@ from frappe.utils import (
 )
 from frappe.utils.user import get_users_with_role
 
+import erpnext
+from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
+	get_checks_for_pl_and_bs_accounts,
+)
+from erpnext.accounts.doctype.journal_entry.journal_entry import make_reverse_journal_entry
 from assets.assets.doctype.asset_activity.asset_activity import add_asset_activity
 from assets.assets.doctype.asset_depreciation_schedule.asset_depreciation_schedule import (
 	get_asset_depr_schedule_doc,
@@ -38,9 +36,7 @@ from assets.assets.doctype.asset_depreciation_schedule.asset_depreciation_schedu
 def post_depreciation_entries(date=None):
 	# Return if automatic booking of asset depreciation is disabled
 	if not cint(
-		frappe.db.get_value(
-			"Accounts Settings", None, "book_asset_depreciation_entry_automatically"
-		)
+		frappe.db.get_value("Accounts Settings", None, "book_asset_depreciation_entry_automatically")
 	):
 		return
 
@@ -90,9 +86,7 @@ def post_depreciation_entries(date=None):
 				date,
 				sch_start_idx,
 				sch_end_idx,
-				credit_and_debit_accounts_for_asset_category_and_company[
-					(asset_category, asset_company)
-				],
+				credit_and_debit_accounts_for_asset_category_and_company[(asset_category, asset_company)],
 				depreciation_cost_center_and_depreciation_series_for_company[asset_company],
 				accounting_dimensions,
 			)
@@ -169,9 +163,7 @@ def get_acc_frozen_upto():
 	return
 
 
-def get_credit_and_debit_accounts_for_asset_category_and_company(
-	asset_category, company
-):
+def get_credit_and_debit_accounts_for_asset_category_and_company(asset_category, company):
 	(
 		_,
 		accumulated_depreciation_account,
@@ -307,9 +299,7 @@ def _make_journal_entry_for_depreciation(
 	je.posting_date = depr_schedule.schedule_date
 	je.company = asset.company
 	je.finance_book = asset_depr_schedule_doc.finance_book
-	je.remark = (
-		f"Depreciation Entry against {asset.name} worth {depr_schedule.depreciation_amount}"
-	)
+	je.remark = f"Depreciation Entry against {asset.name} worth {depr_schedule.depreciation_amount}"
 
 	credit_entry = {
 		"account": credit_account,
@@ -343,7 +333,6 @@ def _make_journal_entry_for_depreciation(
 					or dimension.get("default_dimension")
 				}
 			)
-	update_dimension_fields(asset_depr_schedule_doc.name, credit_entry, debit_entry)
 
 	je.append("accounts", credit_entry)
 	je.append("accounts", debit_entry)
@@ -363,78 +352,7 @@ def _make_journal_entry_for_depreciation(
 		row.db_update()
 
 
-def update_dimension_fields(asset_depr_schedule_doc_name, credit_entry, debit_entry):
-	additional_fields = {}
-	fieldnames = frappe.get_list("Accounting Dimension", {"disabled":0}, pluck="fieldname")
-	for fieldname in fieldnames:
-		field_data = frappe.db.get_value(
-			"Asset Depreciation Schedule", asset_depr_schedule_doc_name, fieldname
-		)
-		additional_fields[fieldname] = field_data
-
-	cost_center = frappe.db.get_value(
-		"Asset Depreciation Schedule", asset_depr_schedule_doc_name, "cost_center"
-	)
-	additional_fields["cost_center"] = cost_center
-
-	credit_entry.update(additional_fields)
-	debit_entry.update(additional_fields)
-
-
-def get_depreciation_accounts(asset_category, company):
-	fixed_asset_account = (
-		accumulated_depreciation_account
-	) = depreciation_expense_account = None
-
-	accounts = frappe.db.get_value(
-		"Asset Category Account",
-		filters={"parent": asset_category, "company_name": company},
-		fieldname=[
-			"fixed_asset_account",
-			"accumulated_depreciation_account",
-			"depreciation_expense_account",
-		],
-		as_dict=1,
-	)
-
-	if accounts:
-		fixed_asset_account = accounts.fixed_asset_account
-		accumulated_depreciation_account = accounts.accumulated_depreciation_account
-		depreciation_expense_account = accounts.depreciation_expense_account
-
-	if not accumulated_depreciation_account or not depreciation_expense_account:
-		accounts = frappe.get_cached_value(
-			"Company",
-			company,
-			["accumulated_depreciation_account", "depreciation_expense_account"],
-		)
-
-		if not accumulated_depreciation_account:
-			accumulated_depreciation_account = accounts[0]
-		if not depreciation_expense_account:
-			depreciation_expense_account = accounts[1]
-
-	if (
-		not fixed_asset_account
-		or not accumulated_depreciation_account
-		or not depreciation_expense_account
-	):
-		frappe.throw(
-			_(
-				"Please set Depreciation related Accounts in Asset Category {0} or Company {1}"
-			).format(asset_category, company)
-		)
-
-	return (
-		fixed_asset_account,
-		accumulated_depreciation_account,
-		depreciation_expense_account,
-	)
-
-
-def get_credit_and_debit_accounts(
-	accumulated_depreciation_account, depreciation_expense_account
-):
+def get_credit_and_debit_accounts(accumulated_depreciation_account, depreciation_expense_account):
 	root_type = frappe.get_value("Account", depreciation_expense_account, "root_type")
 
 	if root_type == "Expense":
@@ -470,19 +388,17 @@ def notify_depr_entry_posting_error(failed_asset_names, error_log_names):
 	message = (
 		_("Hello,")
 		+ "<br><br>"
-		+ _(
-			"The following assets have failed to automatically post depreciation entries: {0}"
-		).format(asset_links)
-		+ "."
-		+ "<br><br>"
-		+ _(
-			"Here are the error logs for the aforementioned failed depreciation entries: {0}"
-		).format(error_log_links)
-		+ "."
-		+ "<br><br>"
-		+ _(
-			"Please share this email with your support team so that they can find and fix the issue."
+		+ _("The following assets have failed to automatically post depreciation entries: {0}").format(
+			asset_links
 		)
+		+ "."
+		+ "<br><br>"
+		+ _("Here are the error logs for the aforementioned failed depreciation entries: {0}").format(
+			error_log_links
+		)
+		+ "."
+		+ "<br><br>"
+		+ _("Please share this email with your support team so that they can find and fix the issue.")
 	)
 
 	frappe.sendmail(recipients=recipients, subject=subject, message=message)
@@ -500,30 +416,19 @@ def get_comma_separated_links(names, doctype):
 
 
 @frappe.whitelist()
-def scrap_asset(asset_name, scrap_date=None):
+def scrap_asset(asset_name):
 	asset = frappe.get_doc("Asset", asset_name)
 
 	if asset.docstatus != 1:
 		frappe.throw(_("Asset {0} must be submitted").format(asset.name))
-	elif asset.status in ("Cancelled", "Sold", "Scrapped", "Capitalized", "Decapitalized"):
-		frappe.throw(
-			_("Asset {0} cannot be scrapped, as it is already {1}").format(
-				asset.name, asset.status
-			)
-		)
+	elif asset.status in ("Cancelled", "Sold", "Scrapped", "Capitalized"):
+		frappe.throw(_("Asset {0} cannot be scrapped, as it is already {1}").format(asset.name, asset.status))
 
-	today_date = getdate(today())
-	date = getdate(scrap_date) or today_date
-	purchase_date = getdate(asset.purchase_date)
-
-	validate_scrap_date(
-		date, today_date, purchase_date, asset.calculate_depreciation, asset_name
-	)
+	date = today()
 
 	notes = _("This schedule was created when Asset {0} was scrapped.").format(
 		get_link_to_form(asset.doctype, asset.name)
 	)
-
 	if asset.status != "Fully Depreciated":
 		depreciate_asset(asset, date, notes)
 		asset.reload()
@@ -553,40 +458,6 @@ def scrap_asset(asset_name, scrap_date=None):
 	add_asset_activity(asset_name, _("Asset scrapped"))
 
 	frappe.msgprint(_("Asset scrapped via Journal Entry {0}").format(je.name))
-
-
-def validate_scrap_date(
-	scrap_date, today_date, purchase_date, calculate_depreciation, asset_name
-):
-	if scrap_date > today_date:
-		frappe.throw(_("Future date is not allowed"))
-	elif scrap_date < purchase_date:
-		frappe.throw(_("Scrap date cannot be before purchase date"))
-
-	if calculate_depreciation:
-		asset_depreciation_schedules = frappe.db.get_all(
-			"Asset Depreciation Schedule",
-			filters={"asset": asset_name, "docstatus": 1},
-			fields=["name"],
-		)
-
-		for depreciation_schedule in asset_depreciation_schedules:
-			last_booked_depreciation_date = frappe.db.get_value(
-				"Depreciation Schedule",
-				{
-					"parent": depreciation_schedule["name"],
-					"docstatus": 1,
-					"journal_entry": ["!=", ""],
-				},
-				"schedule_date",
-				order_by="schedule_date desc",
-			)
-			if (
-				last_booked_depreciation_date
-				and scrap_date < last_booked_depreciation_date
-				and scrap_date > purchase_date
-			):
-				frappe.throw(_("Asset cannot be scrapped before the last depreciation entry."))
 
 
 @frappe.whitelist()
@@ -619,9 +490,7 @@ def depreciate_asset(asset_doc, date, notes):
 
 	asset_doc.flags.ignore_validate_update_after_submit = True
 
-	make_new_active_asset_depr_schedules_and_cancel_current_ones(
-		asset_doc, notes, date_of_disposal=date
-	)
+	make_new_active_asset_depr_schedules_and_cancel_current_ones(asset_doc, notes, date_of_disposal=date)
 
 	asset_doc.save()
 
@@ -642,9 +511,7 @@ def reset_depreciation_schedule(asset_doc, date, notes):
 
 	asset_doc.flags.ignore_validate_update_after_submit = True
 
-	make_new_active_asset_depr_schedules_and_cancel_current_ones(
-		asset_doc, notes, date_of_return=date
-	)
+	make_new_active_asset_depr_schedules_and_cancel_current_ones(asset_doc, notes, date_of_return=date)
 
 	modify_depreciation_schedule_for_asset_repairs(asset_doc, notes)
 
@@ -653,9 +520,7 @@ def reset_depreciation_schedule(asset_doc, date, notes):
 
 def modify_depreciation_schedule_for_asset_repairs(asset, notes):
 	asset_repairs = frappe.get_all(
-		"Asset Repair",
-		filters={"asset": asset.name},
-		fields=["name", "increase_in_asset_life"],
+		"Asset Repair", filters={"asset": asset.name}, fields=["name", "increase_in_asset_life"]
 	)
 
 	for repair in asset_repairs:
@@ -667,17 +532,11 @@ def modify_depreciation_schedule_for_asset_repairs(asset, notes):
 
 def reverse_depreciation_entry_made_after_disposal(asset, date):
 	for row in asset.get("finance_books"):
-		asset_depr_schedule_doc = get_asset_depr_schedule_doc(
-			asset.name, "Active", row.finance_book
-		)
-		if not asset_depr_schedule_doc or not asset_depr_schedule_doc.get(
-			"depreciation_schedule"
-		):
+		asset_depr_schedule_doc = get_asset_depr_schedule_doc(asset.name, "Active", row.finance_book)
+		if not asset_depr_schedule_doc or not asset_depr_schedule_doc.get("depreciation_schedule"):
 			continue
 
-		for schedule_idx, schedule in enumerate(
-			asset_depr_schedule_doc.get("depreciation_schedule")
-		):
+		for schedule_idx, schedule in enumerate(asset_depr_schedule_doc.get("depreciation_schedule")):
 			if schedule.schedule_date == date and schedule.journal_entry:
 				if not disposal_was_made_on_original_schedule_date(
 					schedule_idx, row, date
@@ -714,9 +573,7 @@ def get_depreciation_amount_in_je(journal_entry):
 
 
 # if the invoice had been posted on the date the depreciation was initially supposed to happen, the depreciation shouldn't be undone
-def disposal_was_made_on_original_schedule_date(
-	schedule_idx, row, posting_date_of_disposal
-):
+def disposal_was_made_on_original_schedule_date(schedule_idx, row, posting_date_of_disposal):
 	orginal_schedule_date = add_months(
 		row.depreciation_start_date, schedule_idx * cint(row.frequency_of_depreciation)
 	)
@@ -738,12 +595,7 @@ def disposal_happens_in_the_future(posting_date_of_disposal):
 
 
 def get_gl_entries_on_asset_regain(
-	asset,
-	selling_amount=0,
-	finance_book=None,
-	voucher_type=None,
-	voucher_no=None,
-	date=None,
+	asset, selling_amount=0, finance_book=None, voucher_type=None, voucher_no=None, date=None
 ):
 	if not date:
 		date = getdate()
@@ -796,12 +648,7 @@ def get_gl_entries_on_asset_regain(
 
 
 def get_gl_entries_on_asset_disposal(
-	asset,
-	selling_amount=0,
-	finance_book=None,
-	voucher_type=None,
-	voucher_no=None,
-	date=None,
+	asset, selling_amount=0, finance_book=None, voucher_type=None, voucher_no=None, date=None
 ):
 	if not date:
 		date = getdate()
@@ -861,12 +708,10 @@ def get_asset_details(asset, finance_book=None):
 	value_after_depreciation = asset.get_value_after_depreciation(finance_book)
 	accumulated_depr_amount = flt(asset.gross_purchase_amount) - flt(value_after_depreciation)
 
-	fixed_asset_account, accumulated_depr_account, _ = get_asset_accounts(
-		asset.asset_category, asset.company, accumulated_depr_amount
+	fixed_asset_account, accumulated_depr_account, _ = get_depreciation_accounts(
+		asset.asset_category, asset.company
 	)
-	disposal_account, depreciation_cost_center = get_disposal_account_and_cost_center(
-		asset.company
-	)
+	disposal_account, depreciation_cost_center = get_disposal_account_and_cost_center(asset.company)
 	depreciation_cost_center = asset.cost_center or depreciation_cost_center
 
 	return (
@@ -879,8 +724,13 @@ def get_asset_details(asset, finance_book=None):
 		value_after_depreciation,
 	)
 
-def get_asset_accounts(asset_category, company, accumulated_depr_amount):
+
+def get_depreciation_accounts(asset_category, company):
 	fixed_asset_account = accumulated_depreciation_account = depreciation_expense_account = None
+
+	non_depreciable_category = frappe.db.get_value(
+		"Asset Category", asset_category, "non_depreciable_category"
+	)
 
 	accounts = frappe.db.get_value(
 		"Asset Category Account",
@@ -901,7 +751,7 @@ def get_asset_accounts(asset_category, company, accumulated_depr_amount):
 	if not fixed_asset_account:
 		frappe.throw(_("Please set Fixed Asset Account in Asset Category {0}").format(asset_category))
 
-	if accumulated_depr_amount:
+	if not non_depreciable_category:
 		accounts = frappe.get_cached_value(
 			"Company", company, ["accumulated_depreciation_account", "depreciation_expense_account"]
 		)
@@ -949,21 +799,15 @@ def get_disposal_account_and_cost_center(company):
 	)
 
 	if not disposal_account:
-		frappe.throw(
-			_("Please set 'Gain/Loss Account on Asset Disposal' in Company {0}").format(company)
-		)
+		frappe.throw(_("Please set 'Gain/Loss Account on Asset Disposal' in Company {0}").format(company))
 	if not depreciation_cost_center:
-		frappe.throw(
-			_("Please set 'Asset Depreciation Cost Center' in Company {0}").format(company)
-		)
+		frappe.throw(_("Please set 'Asset Depreciation Cost Center' in Company {0}").format(company))
 
 	return disposal_account, depreciation_cost_center
 
 
 @frappe.whitelist()
-def get_value_after_depreciation_on_disposal_date(
-	asset, disposal_date, finance_book=None
-):
+def get_value_after_depreciation_on_disposal_date(asset, disposal_date, finance_book=None):
 	asset_doc = frappe.get_doc("Asset", asset)
 
 	if asset_doc.available_for_use_date > getdate(disposal_date):
@@ -973,9 +817,7 @@ def get_value_after_depreciation_on_disposal_date(
 			)
 		)
 	elif asset_doc.available_for_use_date == getdate(disposal_date):
-		return flt(
-			asset_doc.gross_purchase_amount - asset_doc.opening_accumulated_depreciation
-		)
+		return flt(asset_doc.gross_purchase_amount - asset_doc.opening_accumulated_depreciation)
 
 	if not asset_doc.calculate_depreciation:
 		return flt(asset_doc.value_after_depreciation)
@@ -993,9 +835,9 @@ def get_value_after_depreciation_on_disposal_date(
 		asset_doc, row, getdate(disposal_date)
 	)
 
-	accumulated_depr_amount = temp_asset_depreciation_schedule.get(
-		"depreciation_schedule"
-	)[-1].accumulated_depreciation_amount
+	accumulated_depr_amount = temp_asset_depreciation_schedule.get("depreciation_schedule")[
+		-1
+	].accumulated_depreciation_amount
 
 	return flt(
 		flt(asset_doc.gross_purchase_amount) - accumulated_depr_amount,

--- a/assets/assets/doctype/asset_capitalization/asset_capitalization.js
+++ b/assets/assets/doctype/asset_capitalization/asset_capitalization.js
@@ -302,7 +302,6 @@ assets.assets.AssetCapitalization = class AssetCapitalization extends (
 		if (me.frm.doc.target_item_code) {
 			return me.frm.call({
 				method: "assets.assets.doctype.asset_capitalization.asset_capitalization.get_target_item_details",
-				child: me.frm.doc,
 				args: {
 					item_code: me.frm.doc.target_item_code,
 					company: me.frm.doc.company,
@@ -322,7 +321,6 @@ assets.assets.AssetCapitalization = class AssetCapitalization extends (
 		if (me.frm.doc.target_asset) {
 			return me.frm.call({
 				method: "assets.assets.doctype.asset_capitalization.asset_capitalization.get_target_asset_details",
-				child: me.frm.doc,
 				args: {
 					asset: me.frm.doc.target_asset,
 					company: me.frm.doc.company,
@@ -425,7 +423,7 @@ assets.assets.AssetCapitalization = class AssetCapitalization extends (
 					args: {
 						item_code: item.item_code,
 						warehouse: cstr(item.warehouse),
-						qty: flt(item.stock_qty),
+						qty: -1 * flt(item.stock_qty),
 						serial_no: item.serial_no,
 						posting_date: me.frm.doc.posting_date,
 						posting_time: me.frm.doc.posting_time,

--- a/assets/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/assets/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -979,8 +979,8 @@ def get_items_tagged_to_wip_composite_asset(params):
 		"valuation_rate",
 		"amount",
 		"is_fixed_asset",
-		"parent",
-		"name",
+		"parent as purchase_receipt",
+		"name as purchase_receipt_item",
 	]
 
 	pr_items = frappe.get_all(
@@ -1007,7 +1007,7 @@ def process_stock_item(d):
 	stock_capitalized = frappe.db.exists(
 		"Asset Capitalization Stock Item",
 		{
-			"purchase_receipt_item": d.name,
+			"purchase_receipt_item": d.purchase_receipt_item,
 			"parentfield": "stock_items",
 			"parenttype": "Asset Capitalization",
 			"docstatus": 1,
@@ -1027,7 +1027,7 @@ def process_fixed_asset(d):
 		"Asset",
 		{
 			"item_code": d.item_code,
-			"purchase_receipt": d.parent,
+			"purchase_receipt": d.purchase_receipt,
 			"status": ("not in", ["Draft", "Scrapped", "Sold", "Capitalized"]),
 		},
 		["name as asset", "asset_name", "company"],

--- a/assets/assets/doctype/asset_category/asset_category.json
+++ b/assets/assets/doctype/asset_category/asset_category.json
@@ -12,6 +12,7 @@
   "column_break_3",
   "depreciation_options",
   "enable_cwip_accounting",
+  "non_depreciable_category",
   "finance_book_detail",
   "finance_books",
   "section_break_2",
@@ -63,8 +64,15 @@
    "fieldname": "enable_cwip_accounting",
    "fieldtype": "Check",
    "label": "Enable Capital Work in Progress Accounting"
+  },
+  {
+   "default": "0",
+   "fieldname": "non_depreciable_category",
+   "fieldtype": "Check",
+   "label": "Non Depreciable Category"
   }
  ],
+ "row_format": "Dynamic",
  "links": [],
  "modified": "2021-02-24 15:05:38.621803",
  "modified_by": "Administrator",

--- a/assets/assets/doctype/asset_category/asset_category.py
+++ b/assets/assets/doctype/asset_category/asset_category.py
@@ -17,9 +17,7 @@ class AssetCategory(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		from assets.assets.doctype.asset_category_account.asset_category_account import (
-			AssetCategoryAccount,
-		)
+		from assets.assets.doctype.asset_category_account.asset_category_account import AssetCategoryAccount
 		from assets.assets.doctype.asset_finance_book.asset_finance_book import (
 			AssetFinanceBook,
 		)
@@ -28,6 +26,7 @@ class AssetCategory(Document):
 		asset_category_name: DF.Data
 		enable_cwip_accounting: DF.Check
 		finance_books: DF.Table[AssetFinanceBook]
+		non_depreciable_category: DF.Check
 	# end: auto-generated types
 
 	def validate(self):

--- a/assets/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/assets/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -280,11 +280,11 @@ class AssetDepreciationSchedule(Document):
 		value_after_depreciation,
 	):
 		asset_doc.validate_asset_finance_books(row)
-
-		if not value_after_depreciation:
-			value_after_depreciation = _get_value_after_depreciation_for_making_schedule(
-				asset_doc, row
-			)
+		if (
+			not value_after_depreciation
+			and not asset_doc.flags.decrease_in_asset_value_due_to_value_adjustment
+		):
+			value_after_depreciation = _get_value_after_depreciation_for_making_schedule(asset_doc, row)
 		row.value_after_depreciation = value_after_depreciation
 
 		if update_asset_finance_book_row:
@@ -631,7 +631,7 @@ def _check_is_pro_rata(asset_doc, row, wdv_or_dd_non_yearly=False):
 		total_days = get_total_days(
 			row.depreciation_start_date, row.frequency_of_depreciation
 		)
-	
+
 	if days <= 0:
 		frappe.throw(
 			_(
@@ -1161,11 +1161,6 @@ def make_new_active_asset_depr_schedules_and_cancel_current_ones(
 			)
 
 		new_asset_depr_schedule_doc = frappe.copy_doc(current_asset_depr_schedule_doc)
-		if (
-			asset_doc.flags.decrease_in_asset_value_due_to_value_adjustment
-			and not value_after_depreciation
-		):
-			value_after_depreciation = row.value_after_depreciation - difference_amount
 
 		if (
 			asset_doc.flags.increase_in_asset_value_due_to_repair
@@ -1245,7 +1240,7 @@ def get_temp_asset_depr_schedule_doc(
 
 @frappe.whitelist()
 def get_depr_schedule(asset_name, status, finance_book=None):
-	
+
 	asset_depr_schedule_doc = get_asset_depr_schedule_doc(asset_name, status, finance_book)
 	if not asset_depr_schedule_doc:
 		return []

--- a/assets/assets/doctype/asset_movement/asset_movement.py
+++ b/assets/assets/doctype/asset_movement/asset_movement.py
@@ -212,8 +212,6 @@ class AssetMovement(Document):
 				as_dict=True,
 			)
 
-			self.validate_movement_cancellation(d, latest_movement_entry)
-
 			if latest_movement_entry:
 				current_location = latest_movement_entry[0]["target_location"]
 				current_employee = latest_movement_entry[0]["to_employee"]
@@ -276,15 +274,6 @@ class AssetMovement(Document):
 						get_link_to_form("Employee", current_employee)
 					),
 				)
-
-	def validate_movement_cancellation(self, row, latest_movement_entry):
-		asset_doc = frappe.get_doc("Asset", row.asset)
-		if not latest_movement_entry and asset_doc.docstatus == 1:
-			frappe.throw(
-				_(
-					"Asset {0} has only one movement record. Please create another movement before deleting this one to maintain asset tracking."
-				).format(row.asset)
-			)
 
 	def on_cancel_reverse_depreciation_schedule(self):
 		transaction_date = getdate(self.transaction_date)

--- a/assets/assets/doctype/asset_movement/test_asset_movement.py
+++ b/assets/assets/doctype/asset_movement/test_asset_movement.py
@@ -84,7 +84,7 @@ class TestAssetMovement(unittest.TestCase):
 					"target_location":"Field 1",
 					"source_cost_center":"_Test Cost Center - _TC"
 				}]
-			}) 
+			})
 			asset_movement.insert()
 			asset_movement.submit()
 
@@ -160,7 +160,7 @@ class TestAssetMovement(unittest.TestCase):
 					"to_employee":employee_doc.name,
 					"source_cost_center":"_Test Cost Center - _TC"
 				}]
-			}) 
+			})
 			asset_movement.insert()
 			asset_movement.submit()
 
@@ -236,7 +236,7 @@ class TestAssetMovement(unittest.TestCase):
 					"to_employee":employee_doc.name,
 					"source_cost_center":"_Test Cost Center - _TC"
 				}]
-			}) 
+			})
 			asset_movement.insert()
 			asset_movement.submit()
 
@@ -263,7 +263,7 @@ class TestAssetMovement(unittest.TestCase):
 			# Check if 'gst_hsn_code' exists in Item doctype
 			if frappe.db.has_column("Item", "gst_hsn_code"):
 				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
-			
+
 			frappe.get_doc(item_data).insert()
 
 		if not frappe.db.exists("Employee", "Test_employee_issue"):
@@ -308,7 +308,7 @@ class TestAssetMovement(unittest.TestCase):
 		}).insert()
 		target_asset.submit()
 
-		
+
 
 		if target_asset:
 			asset_movement = frappe.get_doc({
@@ -322,7 +322,7 @@ class TestAssetMovement(unittest.TestCase):
 					"target_location":"Field 1",
 					"source_cost_center":"_Test Cost Center - _TC"
 				}]
-			}) 
+			})
 			asset_movement.insert()
 			asset_movement.submit()
 
@@ -483,7 +483,7 @@ class TestAssetMovement(unittest.TestCase):
 					"to_employee":employee_doc.name,
 					"source_cost_center":"_Test Cost Center - _TC"
 				}]
-			}) 
+			})
 			asset_movement.insert()
 			asset_movement.submit()
 
@@ -577,7 +577,7 @@ class TestAssetMovement(unittest.TestCase):
 					"to_employee":employee_doc.name,
 					"source_cost_center":"_Test Cost Center - _TC"
 				}]
-			}) 
+			})
 			asset_movement.insert()
 			asset_movement.submit()
 
@@ -598,7 +598,7 @@ class TestAssetMovement(unittest.TestCase):
 
 		# Assertions
 		self.assertEqual(target_asset.docstatus, 2)  # Ensure Asset is canceled
-	
+
 	#TC_FA_122
 	def test_cancel_asset_movement_issue_from_employee_to_target_location_TC_FA_122(self):
 		company = "_Test Company"
@@ -622,7 +622,7 @@ class TestAssetMovement(unittest.TestCase):
 			if frappe.db.has_column("Item", "gst_hsn_code"):
 				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
 			frappe.get_doc(item_data).insert()
-		
+
 		if not frappe.db.exists("Employee", "Test_employee_issue"):
 			employee_doc = frappe.get_doc({
 				"doctype": "Employee",
@@ -732,7 +732,7 @@ class TestAssetMovement(unittest.TestCase):
 				"status": "Active",
 				"company": company
 			}).insert()
-			
+
 		asset_doc_name = frappe.get_doc({
 			"doctype": "Asset",
 			"company": company,
@@ -770,7 +770,7 @@ class TestAssetMovement(unittest.TestCase):
 					"target_location":"Division 1",
 					"source_cost_center":"_Test Cost Center - _TC"
 				}]
-			}) 
+			})
 			asset_movement.insert()
 			asset_movement.submit()
 
@@ -860,7 +860,7 @@ class TestAssetMovement(unittest.TestCase):
 
 		# Assertions
 		self.assertEqual(target_asset.docstatus, 2)  # Ensure Asset is canceled
-	
+
 	#TC_FA_124
 	def test_cancel_multiple_asset_movement_issue_location_change_TC_FA_124(self):
 		company = "_Test Company"
@@ -934,7 +934,7 @@ class TestAssetMovement(unittest.TestCase):
 					"to_employee":employee_doc.name,
 					"source_cost_center":"_Test Cost Center - _TC"
 				}]
-			}) 
+			})
 			asset_movement.insert()
 			asset_movement.submit()
 
@@ -1029,7 +1029,7 @@ class TestAssetMovement(unittest.TestCase):
 					"to_employee":employee_doc.name,
 					"source_cost_center":"_Test Cost Center - _TC"
 				}]
-			}) 
+			})
 			asset_movement.insert()
 			asset_movement.submit()
 
@@ -1050,7 +1050,7 @@ class TestAssetMovement(unittest.TestCase):
 
 		# Assertions
 		self.assertEqual(target_asset.docstatus, 2)  # Ensure Asset is canceled
-	
+
 	#TC_FA_126
 	def test_cancel_multiple_asset_movement_issue_from_employee_to_target_location_TC_FA_126(self):
 		company = "_Test Company"
@@ -1075,7 +1075,7 @@ class TestAssetMovement(unittest.TestCase):
 				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
 
 			frappe.get_doc(item_data).insert()
-		
+
 		if not frappe.db.exists("Employee", "Test_employee_issue"):
 			employee_doc = frappe.get_doc({
 				"doctype": "Employee",
@@ -1148,7 +1148,7 @@ class TestAssetMovement(unittest.TestCase):
 
 		# Assertions
 		self.assertEqual(target_asset.docstatus, 2)  # Ensure Asset is canceled
-	
+
 	#TC_FA_127
 	def test_cancel_single_asset_movement_transfer_location_change_TC_FA_127(self):
 		company = "_Test Company"
@@ -1306,7 +1306,7 @@ class TestAssetMovement(unittest.TestCase):
 					"to_employee":employee_doc.name,
 					"source_cost_center":"_Test Cost Center - _TC"
 				}]
-			}) 
+			})
 			asset_movement.insert()
 			asset_movement.submit()
 
@@ -1400,7 +1400,7 @@ class TestAssetMovement(unittest.TestCase):
 					"to_employee":employee_doc.name,
 					"source_cost_center":"_Test Cost Center - _TC"
 				}]
-			}) 
+			})
 			asset_movement.insert()
 			asset_movement.submit()
 
@@ -1441,7 +1441,7 @@ class TestAssetMovement(unittest.TestCase):
 				"auto_create_assets": 1,
 				"asset_category": "Test_Category"
 			}
-			
+
 			# Check if 'gst_hsn_code' exists in Item doctype
 			if frappe.db.has_column("Item", "gst_hsn_code"):
 				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
@@ -1605,7 +1605,7 @@ class TestAssetMovement(unittest.TestCase):
 
 		# Assertions
 		self.assertEqual(target_asset.docstatus, 2)  # Ensure Asset is canceled
-	
+
 	#TC_FA_132
 	def test_cancel_multiple_grouped_asset_movement_issue_location_change_TC_FA_132(self):
 		company = "_Test Company"
@@ -1679,7 +1679,7 @@ class TestAssetMovement(unittest.TestCase):
 					"to_employee":employee_doc.name,
 					"source_cost_center":"_Test Cost Center - _TC"
 				}]
-			}) 
+			})
 			asset_movement.insert()
 			asset_movement.submit()
 
@@ -1774,7 +1774,7 @@ class TestAssetMovement(unittest.TestCase):
 					"to_employee":employee_doc.name,
 					"source_cost_center":"_Test Cost Center - _TC"
 				}]
-			}) 
+			})
 			asset_movement.insert()
 			asset_movement.submit()
 
@@ -1795,7 +1795,7 @@ class TestAssetMovement(unittest.TestCase):
 
 		# Assertions
 		self.assertEqual(target_asset.docstatus, 2)  # Ensure Asset is canceled
-	
+
 	#TC_FA_134
 	def test_cancel_multiple_grouped_asset_movement_issue_from_employee_to_target_location_TC_FA_134(self):
 		company = "_Test Company"
@@ -1820,7 +1820,7 @@ class TestAssetMovement(unittest.TestCase):
 				item_data["gst_hsn_code"] = "01011010"  # Add only if field exists
 
 			frappe.get_doc(item_data).insert()
-		
+
 		if not frappe.db.exists("Employee", "Test_employee_issue"):
 			employee_doc = frappe.get_doc({
 				"doctype": "Employee",
@@ -1992,7 +1992,7 @@ class TestAssetMovement(unittest.TestCase):
 		company = "_Test Company"
 		employee = "_T-Employee-00001"
 		item = "Test_item_01"
-		
+
 		# Ensure prerequisites exist
 		if not frappe.db.exists("Company", company):
 			create_child_company()
@@ -2078,7 +2078,7 @@ class TestAssetMovement(unittest.TestCase):
 		company = "_Test Company"
 		employee = "_T-Employee-00001"
 		item = "Test_item_01"
-		
+
 		# Ensure prerequisites exist
 		if not frappe.db.exists("Company", company):
 			create_child_company()
@@ -2458,7 +2458,7 @@ class TestAssetMovement(unittest.TestCase):
 				"status": "Active",
 				"company": company
 			}).insert()
-			
+
 		asset_doc_name = frappe.get_doc({
 			"doctype": "Asset",
 			"company": company,
@@ -2496,7 +2496,7 @@ class TestAssetMovement(unittest.TestCase):
 					"target_location":"Field 1",
 					"source_cost_center":"_Test Cost Center - _TC"
 				}]
-			}) 
+			})
 			asset_movement.insert()
 			asset_movement.submit()
 
@@ -2518,7 +2518,7 @@ class TestAssetMovement(unittest.TestCase):
 				"auto_create_assets": 1,
 				"asset_category": "Test_Category"
 			}).insert()
-		
+
 		if not frappe.db.exists("Employee", "Test_employee_issue"):
 			employee_doc = frappe.get_doc({
 				"doctype": "Employee",
@@ -2570,7 +2570,7 @@ class TestAssetMovement(unittest.TestCase):
 					"from_employee":employee_doc.name,
 					"target_location":"Field 1",
 				}]
-			}) 
+			})
 			asset_movement.insert()
 			asset_movement.submit()
 
@@ -2902,7 +2902,7 @@ class TestAssetMovement(unittest.TestCase):
 				"auto_create_assets": 1,
 				"asset_category": "Test_Category"
 			}).insert()
-		
+
 		employe_doc = frappe.get_doc({
 				"doctype": "Employee",
 				"employee_name": "Test_Employee_Grouped1",
@@ -2913,9 +2913,9 @@ class TestAssetMovement(unittest.TestCase):
 				"status": "Active",
 				"company": company
 			}).insert()
-		
+
 		employe_doc.submit()
-		
+
 		target_asset = frappe.get_doc({
 			"doctype": "Asset",
 			"company": company,
@@ -2953,7 +2953,7 @@ class TestAssetMovement(unittest.TestCase):
 					"from_employee":employe_doc.idx,
 					"target_location":"Field 1",
 				}]
-			}) 
+			})
 			asset_movement.insert()
 			asset_movement.submit()
 
@@ -3189,45 +3189,6 @@ class TestAssetMovement(unittest.TestCase):
 		self.assertEqual(
 			frappe.db.get_value("Asset", asset.name, "location"), "Test Location"
 		)
-
-	def test_last_movement_cancellation_validation(self):
-		pr = make_purchase_receipt(item_code="Macbook Pro", qty=1, rate=100000.0, location="Test Location")
-
-		asset_name = frappe.db.get_value("Asset", {"purchase_receipt": pr.name}, "name")
-		asset = frappe.get_doc("Asset", asset_name)
-		asset.calculate_depreciation = 1
-		asset.available_for_use_date = "2020-06-06"
-		asset.purchase_date = "2020-06-06"
-		asset.append(
-			"finance_books",
-			{
-				"expected_value_after_useful_life": 10000,
-				"next_depreciation_date": "2020-12-31",
-				"depreciation_method": "Straight Line",
-				"total_number_of_depreciations": 3,
-				"frequency_of_depreciation": 10,
-			},
-		)
-		if asset.docstatus == 0:
-			asset.submit()
-
-		AssetMovement = frappe.qb.DocType("Asset Movement")
-		AssetMovementItem = frappe.qb.DocType("Asset Movement Item")
-
-		asset_movement = (
-			frappe.qb.from_(AssetMovement)
-			.join(AssetMovementItem)
-			.on(AssetMovementItem.parent == AssetMovement.name)
-			.select(AssetMovement.name)
-			.where(
-				(AssetMovementItem.asset == asset.name)
-				& (AssetMovement.company == asset.company)
-				& (AssetMovement.docstatus == 1)
-			)
-		).run(as_dict=True)
-
-		asset_movement_doc = frappe.get_doc("Asset Movement", asset_movement[0].name)
-		self.assertRaises(frappe.ValidationError, asset_movement_doc.cancel)
 
 	def test_depriciation_schedule_entry(self):
 		pr = make_purchase_receipt(

--- a/assets/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
+++ b/assets/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
@@ -8,7 +8,7 @@ from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 )
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import flt, formatdate, get_link_to_form, getdate
+from frappe.utils import flt, formatdate, get_link_to_form, getdate, cstr
 
 from assets.assets.doctype.asset.asset import get_asset_value_after_depreciation
 from assets.assets.doctype.asset.depreciation import get_depreciation_accounts
@@ -194,12 +194,21 @@ class AssetValueAdjustment(Document):
 				get_link_to_form(self.get("doctype"), self.get("name")),
 			)
 
+		difference_amount = self.difference_amount if self.docstatus == 1 else -1 * self.difference_amount
+		if asset.calculate_depreciation:
+			for row in asset.finance_books:
+				if cstr(row.finance_book) == cstr(self.finance_book):
+					row.value_after_depreciation += flt(difference_amount)
+					row.db_update()
+
+		asset.db_update()
+
 		make_new_active_asset_depr_schedules_and_cancel_current_ones(
 			asset,
 			notes,
 			value_after_depreciation=asset_value,
 			ignore_booked_entry=True,
-			difference_amount=self.difference_amount,
+			difference_amount=difference_amount,
 		)
 		asset.flags.ignore_validate_update_after_submit = True
 		asset.save()


### PR DESCRIPTION
**asset standard version-15 commits from 6th May to 3rd June**

### Bug Fixes
- Deprecated the unused original get_depreciation_accounts definition and refactored get_asset_details to call the updated one. Prevents unnecessary errors for non-depreciating asset flows.
- fix: only depreciable category assets are allowed for depreciation
- fix: alias name and parent to prevent child row mapping issues in asset capitalization
- fix: removed invalid child param to prevent callback failure from asset capitalization
- fix(asset): resolve image field not updating from item code
  - Added fetch_if_empty: 1 to the image field in the Asset doctype to ensure the image is fetched from the linked Item when the Asset's image field is empty.
- Removed restrictive validation that prevented cancelling the last submitted asset movement.Previously, users could not cancel the final movement record, even if required, making it difficult to update or correct records.This fix enables smooth cancellation and updates asset’s current location and custodian accordingly after cancellation.
- fix: incorrect valuation rate due to positive qty in asset capitalization
- fix: updated value after depreciation after value adjustment
  - Removes redundant and misplaced logic in depreciation schedule calculation where value_after_depreciation was being unnecessarily recalculated.Corrects the difference_amount sign when cancelling Asset Value Adjustments to ensure consistency in back-calculations.
- made changes specifically for value adjustment entry




### Feature
 - **feat(asset-category): add "Non Depreciable Category" checkbox**
    - Introduced a new checkbox field non_depreciable_category in the Asset Category doctype.
    - This allows categorizing assets that should not undergo depreciation.