### PR TITLE
Assets commits till 18th june

### DIFF
--- a/assets/assets/customizations/accounts/sales_invoice/override.py
+++ b/assets/assets/customizations/accounts/sales_invoice/override.py
@@ -31,7 +31,9 @@ def make_item_gl_entries(self, gl_entries):
 				if item.is_fixed_asset:
 					asset = get_asset(self, item)
 
-					if self.is_return:
+					if (self.docstatus == 2 and not self.is_return) or (
+						self.docstatus == 1 and self.is_return
+					):
 						fixed_asset_gl_entries = get_gl_entries_on_asset_regain(
 							asset,
 							item.base_net_amount,
@@ -44,8 +46,10 @@ def make_item_gl_entries(self, gl_entries):
 						add_asset_activity(asset.name, _("Asset returned"))
 
 						if asset.calculate_depreciation:
-							posting_date = frappe.db.get_value(
-								"Sales Invoice", self.return_against, "posting_date"
+							posting_date = (
+								frappe.db.get_value("Sales Invoice", self.return_against, "posting_date")
+								if self.is_return
+								else self.posting_date
 							)
 							reverse_depreciation_entry_made_after_disposal(asset, posting_date)
 							notes = _(
@@ -131,8 +135,10 @@ def get_asset(doc, item):
     return asset
 
 def set_asset_status(doc, asset):
-    if doc.is_return:
+    if doc.is_return and not doc.docstatus == 2:
         asset.set_status()
+    elif doc.is_return and doc.docstatus == 2:
+        asset.set_status("Sold")
     else:
         asset.set_status("Sold" if doc.docstatus == 1 else None)
 

--- a/assets/assets/doctype/asset/asset.js
+++ b/assets/assets/doctype/asset/asset.js
@@ -84,6 +84,12 @@ frappe.ui.form.on("Asset", {
 				},
 			};
 		});
+
+		if (frm.doc.docstatus == 1) {
+			frm.custom_make_buttons = {
+				"Asset Capitalization": "Asset Capitalization",
+			};
+		}
 	},
 
 	refresh: function (frm) {

--- a/assets/assets/doctype/asset/asset.py
+++ b/assets/assets/doctype/asset/asset.py
@@ -98,7 +98,7 @@ class Asset(AccountsController):
 		opening_number_of_booked_depreciations: DF.Int
 		policy_number: DF.Data | None
 		purchase_amount: DF.Currency
-		purchase_date: DF.Date | None
+		purchase_date: DF.Date
 		purchase_invoice: DF.Link | None
 		purchase_receipt: DF.Link | None
 		split_from: DF.Link | None

--- a/assets/assets/doctype/asset/depreciation.py
+++ b/assets/assets/doctype/asset/depreciation.py
@@ -824,7 +824,7 @@ def get_value_after_depreciation_on_disposal_date(asset, disposal_date, finance_
 
 	idx = 1
 	if finance_book:
-		for d in asset.finance_books:
+		for d in asset_doc.finance_books:
 			if d.finance_book == finance_book:
 				idx = d.idx
 				break

--- a/assets/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
+++ b/assets/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
@@ -212,6 +212,7 @@ class AssetValueAdjustment(Document):
 		)
 		asset.flags.ignore_validate_update_after_submit = True
 		asset.save()
+		asset.set_status()
 
 
 @frappe.whitelist()


### PR DESCRIPTION
**Asset standard version-15 commits from 3rd june to 18th June**
### Bug Fixes
 - fix(asset): make purchase date mandatory - In asset.json, the field definition for "purchase_date" is modified to add "reqd": 1 (i.e. make it a required field).
 - fix: AttributeError due to incorrect object - In the file erpnext/assets/doctype/asset/depreciation.py, inside the function get_value_after_depreciation_on_disposal_date, the loop over finance books was changed.
 - fix: do not allow capitalization from connection tab for submitted asset - It introduces logic so that when an Asset document is already submitted (docstatus == 1), the “Asset Capitalization” action (or “capitalization” from the Connection tab) is made available via custom_make_buttons
 - fix: update asset status after making asset value adjustment record
 - fix(asset-invoice): handle asset invoice cancellation - Originally, when an invoice with fixed-asset items was cancelled (or in return scenarios), some GL entries related to asset depreciation reversal or disposal might be incorrectly computed or omitted
 - 