### PR TITLE
SyntaxError in asset.py: unclosed '(' from duplicated depreciation validation block

### DIFF
--- a/assets/assets/doctype/asset/asset.py
+++ b/assets/assets/doctype/asset/asset.py
@@ -618,24 +618,6 @@ class Asset(AccountsController):
 					"Row {0}: Total Number of Depreciations cannot be less than or equal to Opening Number of Booked Depreciations"
 				).format(row.idx),
 				title=_("Invalid Schedule"),
-			frappe.throw(
-				_("Opening Accumulated Depreciation must be less than or equal to {0}").format(
-					depreciable_amount
-				)
-			)
-
-		if self.opening_accumulated_depreciation:
-			if not self.opening_number_of_booked_depreciations:
-				frappe.throw(_("Please set Opening Number of Booked Depreciations"))
-		else:
-			self.opening_number_of_booked_depreciations = 0
-
-		if flt(row.total_number_of_depreciations) <= cint(self.opening_number_of_booked_depreciations):
-			frappe.throw(
-				_(
-					"Row {0}: Total Number of Depreciations cannot be less than or equal to Opening Number of Booked Depreciations"
-				).format(row.idx),
-				title=_("Invalid Schedule"),
 			)		
 	
 	def set_total_booked_depreciations(self):


### PR DESCRIPTION
Fixes the `SyntaxError: '(' was never closed` in `Asset.validate_opening_depreciation_values()` described in the linked issue - the validation block was duplicated, with the first copy missing its closing paren.

Removed the broken duplicate; the remaining block is unchanged behavior.

Closes #306