### PR TITLE
SyntaxError in test_asset_repair.py: duplicate 'item' keyword argument

### DIFF
--- a/assets/assets/doctype/asset_repair/test_asset_repair.py
+++ b/assets/assets/doctype/asset_repair/test_asset_repair.py
@@ -1283,7 +1283,6 @@ def create_asset_repair(**args):
 			pi1 = make_purchase_invoice(
 				item=args.item or "_Test Non Stock Item",
 				company=asset.company,
-				item=args.item or "_Test Item",
 				expense_account=args.pi_expense_account1 or "Administrative Expenses - _TC",
 				cost_center=asset_repair.cost_center,
 				warehouse=args.warehouse


### PR DESCRIPTION
Fixes the `SyntaxError: keyword argument repeated: item` in `test_asset_repair.py` described in the linked issue.

Removed the duplicate `item=` argument, keeping the `_Test Non Stock Item` default that matches this file's existing pattern for `capitalize_repair_cost` scenarios.

Closes #308